### PR TITLE
refactor: propagate user_id as uuid.UUID throughout the stack

### DIFF
--- a/backend/core/auth/dependencies.py
+++ b/backend/core/auth/dependencies.py
@@ -1,5 +1,6 @@
 """FastAPI dependency injection for auth."""
 
+import uuid
 from typing import Annotated
 
 from fastapi import Depends, Header, HTTPException, status
@@ -39,7 +40,7 @@ def get_session_manager(
 async def get_current_user_id(
     jwt_manager: Annotated[JWTTokenManager, Depends(get_jwt_token_manager)],
     authorization: Annotated[str | None, Header()] = None,
-) -> str:
+) -> uuid.UUID:
     """
     Extract and validate current user from authorization header.
 

--- a/backend/core/auth/managers/jwt.py
+++ b/backend/core/auth/managers/jwt.py
@@ -81,7 +81,7 @@ class JWTTokenManager:
         except Exception as e:
             raise InvalidTokenError(f"Invalid token: {e}")
 
-    def extract_user_id_from_access_token(self, access_token: str) -> str:
+    def extract_user_id_from_access_token(self, access_token: str) -> uuid.UUID:
         payload = self.decode_access_token(access_token)
         user_id = payload.get("sub")
 
@@ -89,6 +89,9 @@ class JWTTokenManager:
             raise InvalidTokenError("User ID not found in access token")
 
         if not isinstance(user_id, str):
-            raise Exception("User ID is not a string")
+            raise InvalidTokenError("User ID is not a string")
 
-        return user_id
+        try:
+            return uuid.UUID(user_id)
+        except ValueError as e:
+            raise InvalidTokenError(f"User ID is not a valid UUID: {user_id}") from e

--- a/backend/core/auth/managers/session.py
+++ b/backend/core/auth/managers/session.py
@@ -52,12 +52,7 @@ class SessionManager:
         logger.info(f"Created session for user: {user_id}")
         return AuthSessionSchema.model_validate(new_session)
 
-    async def find_session_by_user_id(
-        self, user_id: str | uuid.UUID
-    ) -> AuthSession | None:
-        if isinstance(user_id, str):
-            user_id = uuid.UUID(user_id)
-
+    async def find_session_by_user_id(self, user_id: uuid.UUID) -> AuthSession | None:
         query = (
             select(AuthSession)
             .where(AuthSession.user_id == user_id)
@@ -68,11 +63,8 @@ class SessionManager:
         return session
 
     async def find_best_matching_session(
-        self, user_id: str | uuid.UUID, ip: str | None, user_agent: str | None
+        self, user_id: uuid.UUID, ip: str | None, user_agent: str | None
     ) -> AuthSession | None:
-        if isinstance(user_id, str):
-            user_id = uuid.UUID(user_id)
-
         # Priority 1: Match user_id, ip AND user_agent
         query = select(AuthSession).where(
             AuthSession.user_id == user_id,

--- a/backend/core/auth/managers/user.py
+++ b/backend/core/auth/managers/user.py
@@ -39,10 +39,7 @@ class UserManager:
         self._db = db_session
         self._password_hasher = password_hasher or get_password_hasher()
 
-    async def find_user_by_id(self, user_id: uuid.UUID | str) -> Optional[User]:
-        if isinstance(user_id, str):
-            user_id = uuid.UUID(user_id)
-
+    async def find_user_by_id(self, user_id: uuid.UUID) -> Optional[User]:
         query = select(User).where(User.id == user_id)
         user = await self._db.scalar(query)
         return user

--- a/backend/core/auth/router.py
+++ b/backend/core/auth/router.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Annotated, Literal, Optional
 
 from fastapi import (
@@ -279,7 +280,7 @@ async def refresh(
 
 @router.get("/me")
 async def me(
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     user_manager: Annotated[UserManager, Depends(get_user_manager)],
 ) -> UserResponse:
     """

--- a/backend/core/sockets/handlers.py
+++ b/backend/core/sockets/handlers.py
@@ -3,6 +3,7 @@ from loguru import logger
 from agents.manager import Manager
 from agents.types import DirectorRequest
 from core.auth import SessionManager
+from core.auth.exceptions import InvalidTokenError
 from core.auth.managers.jwt import JWTTokenManager
 from core.common import AliasedBaseModel
 from core.services.database import async_session_maker
@@ -30,7 +31,11 @@ async def connect(sid: str, environ: dict, auth: dict) -> bool:
         return False
 
     jwt_manager = JWTTokenManager()
-    user_id = jwt_manager.extract_user_id_from_access_token(auth["accessToken"])
+    try:
+        user_id = jwt_manager.extract_user_id_from_access_token(auth["accessToken"])
+    except InvalidTokenError:
+        logger.debug("Invalid access token, closing connection")
+        return False
     target_room = None
 
     async with async_session_maker() as async_db_session:

--- a/backend/core/story_engine/api/dependencies.py
+++ b/backend/core/story_engine/api/dependencies.py
@@ -15,7 +15,7 @@ from ..service import CharacterService, ImageService, ProjectService, StoryServi
 
 async def verify_project_access(
     project_id: uuid.UUID,
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     db: Annotated[AsyncSession, Depends(get_async_db_session)],
 ) -> uuid.UUID:
     # Verify that the user has access to the project.
@@ -26,7 +26,7 @@ async def verify_project_access(
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
 
-    if project.user_id != uuid.UUID(user_id):
+    if project.user_id != user_id:
         raise HTTPException(
             status_code=403, detail="User does not have access to project"
         )

--- a/backend/core/story_engine/api/phases.py
+++ b/backend/core/story_engine/api/phases.py
@@ -72,7 +72,7 @@ async def extract_characters(
 
 @router.get("/dummy")
 async def dummy(
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     session_manager: Annotated[SessionManager, Depends(get_session_manager)],
 ) -> dict[str, str]:
     session = await session_manager.find_session_by_user_id(user_id)
@@ -87,7 +87,7 @@ async def dummy(
 @router.post("/render-character/{project_id}")
 async def render_character(
     project_id: Annotated[uuid.UUID, Depends(verify_project_access)],
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     db: Annotated[AsyncSession, Depends(get_async_db_session)],
     character: Character,
     session_manager: Annotated[SessionManager, Depends(get_session_manager)],
@@ -124,7 +124,7 @@ async def render_character(
 @router.get("/generate-panels/{project_id}")
 async def generate_panels(
     project_id: Annotated[uuid.UUID, Depends(verify_project_access)],
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     db: Annotated[AsyncSession, Depends(get_async_db_session)],
     session_manager: Annotated[SessionManager, Depends(get_session_manager)],
 ) -> dict:
@@ -181,7 +181,7 @@ async def generate_story(
 @router.post("/render-panel/{project_id}")
 async def render_panel(
     project_id: Annotated[uuid.UUID, Depends(verify_project_access)],
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     db: Annotated[AsyncSession, Depends(get_async_db_session)],
     panel: ComicPanel,
     session_manager: Annotated[SessionManager, Depends(get_session_manager)],
@@ -218,7 +218,7 @@ async def render_panel(
 @router.post("/render-all-panels/{project_id}")
 async def render_all_panels(
     project_id: Annotated[uuid.UUID, Depends(verify_project_access)],
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     db: Annotated[AsyncSession, Depends(get_async_db_session)],
     session_manager: Annotated[SessionManager, Depends(get_session_manager)],
 ) -> dict:

--- a/backend/core/story_engine/api/projects.py
+++ b/backend/core/story_engine/api/projects.py
@@ -24,10 +24,10 @@ logger = logger.bind(name=__name__)
 
 @router.get("/projects")
 async def list_projects(
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     db: Annotated[AsyncSession, Depends(get_async_db_session)],
 ) -> list[ProjectListResponseSchema]:
-    query = select(Project).where(Project.user_id == uuid.UUID(user_id))
+    query = select(Project).where(Project.user_id == user_id)
     result = await db.execute(query)
     projects = result.scalars().all()
     return [ProjectListResponseSchema.model_validate(p) for p in projects]
@@ -35,11 +35,11 @@ async def list_projects(
 
 @router.post("/projects", status_code=status.HTTP_201_CREATED)
 async def create_project(
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     db: Annotated[AsyncSession, Depends(get_async_db_session)],
     project_data: ProjectCreateSchema,
 ) -> ProjectResponseSchema:
-    project = Project(user_id=uuid.UUID(user_id), name=project_data.name)
+    project = Project(user_id=user_id, name=project_data.name)
     db.add(project)
     await db.commit()
     await db.refresh(project)
@@ -49,12 +49,10 @@ async def create_project(
 @router.get("/projects/{project_id}")
 async def get_project(
     project_id: uuid.UUID,
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     db: Annotated[AsyncSession, Depends(get_async_db_session)],
 ) -> ProjectResponseSchema:
-    query = select(Project).where(
-        Project.id == project_id, Project.user_id == uuid.UUID(user_id)
-    )
+    query = select(Project).where(Project.id == project_id, Project.user_id == user_id)
     result = await db.execute(query)
     project = result.scalar_one_or_none()
     if not project:
@@ -67,13 +65,11 @@ async def get_project(
 @router.patch("/projects/{project_id}")
 async def update_project(
     project_id: uuid.UUID,
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     db: Annotated[AsyncSession, Depends(get_async_db_session)],
     update_data: ProjectUpdateSchema,
 ) -> ProjectResponseSchema:
-    query = select(Project).where(
-        Project.id == project_id, Project.user_id == uuid.UUID(user_id)
-    )
+    query = select(Project).where(Project.id == project_id, Project.user_id == user_id)
     result = await db.execute(query)
     project = result.scalar_one_or_none()
     if not project:
@@ -93,12 +89,10 @@ async def update_project(
 @router.delete("/projects/{project_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_project(
     project_id: uuid.UUID,
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     db: Annotated[AsyncSession, Depends(get_async_db_session)],
 ) -> None:
-    query = select(Project).where(
-        Project.id == project_id, Project.user_id == uuid.UUID(user_id)
-    )
+    query = select(Project).where(Project.id == project_id, Project.user_id == user_id)
     result = await db.execute(query)
     project = result.scalar_one_or_none()
     if not project:

--- a/backend/core/story_engine/api/v2/character.py
+++ b/backend/core/story_engine/api/v2/character.py
@@ -198,7 +198,7 @@ async def upload_reference_image(
     story_id: uuid.UUID,
     character_id: uuid.UUID,
     service: Annotated[CharacterService, Depends(get_character_service)],
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     image: UploadFile = File(...),
 ) -> ImageResponseSchema:
     try:
@@ -228,7 +228,7 @@ async def get_character_reference_images(
     project_id: uuid.UUID,
     story_id: uuid.UUID,
     character_id: uuid.UUID,
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     service: Annotated[ImageService, Depends(get_image_service)],
 ) -> list[ImageResponseSchema]:
     try:

--- a/backend/core/story_engine/api/v2/images.py
+++ b/backend/core/story_engine/api/v2/images.py
@@ -17,7 +17,7 @@ router = APIRouter(tags=["images", "v2"])
 @router.get("/image/{image_id}/signed-url", status_code=200)
 async def get_image_signed_url(
     image_id: uuid.UUID,
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     service: Annotated[ImageService, Depends(get_image_service)],
 ) -> ImageSignedUrlResponseSchema:
     try:

--- a/backend/core/story_engine/api/v2/projects.py
+++ b/backend/core/story_engine/api/v2/projects.py
@@ -22,7 +22,7 @@ router = APIRouter(tags=["comic", "builder", "v2", "projects"])
 
 @router.get("/projects")
 async def get_all_projects_of_user(
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     service: Annotated[ProjectService, Depends(get_project_service)],
 ) -> list[ProjectListResponseSchema]:
     projects = await service.get_all_projects_of_user(user_id)
@@ -40,7 +40,7 @@ async def get_all_projects_of_user(
 
 @router.post("/projects")
 async def create_project(
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     project_data: ProjectCreateSchema,
     service: Annotated[ProjectService, Depends(get_project_service)],
 ) -> ProjectResponseSchema:
@@ -51,7 +51,7 @@ async def create_project(
 @router.get("/projects/{project_id}")
 async def get_project(
     project_id: uuid.UUID,
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     service: Annotated[ProjectService, Depends(get_project_service)],
 ) -> ProjectRelationalStateSchema:
     project = await service.get_project_details(user_id, project_id)
@@ -65,7 +65,7 @@ async def get_project(
 @router.post("/projects/{project_id}/story")
 async def create_story(
     project_id: uuid.UUID,
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     story_data: StoryCreateSchema,
     service: Annotated[ProjectService, Depends(get_project_service)],
 ) -> StoryResponseSchema:
@@ -77,7 +77,7 @@ async def create_story(
 async def delete_story(
     project_id: uuid.UUID,
     story_id: uuid.UUID,
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     service: Annotated[ProjectService, Depends(get_project_service)],
 ) -> None:
     try:

--- a/backend/core/story_engine/api/v2/story.py
+++ b/backend/core/story_engine/api/v2/story.py
@@ -25,7 +25,7 @@ router = APIRouter(tags=["story"])
 async def get_story(
     project_id: uuid.UUID,
     story_id: uuid.UUID,
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     service: Annotated[StoryService, Depends(get_story_service)],
 ) -> StoryResponseSchema:
     story = await service.get_story(project_id, story_id)
@@ -44,7 +44,7 @@ async def _as_ndjson(stream: AsyncIterator[EventEnvelope]) -> AsyncIterator[str]
 @router.post("/project/{project_id}/story/{story_id}/generate")
 async def generate_story(
     user_id: Annotated[
-        str,
+        uuid.UUID,
         Depends(get_current_user_id),
     ],
     project_id: uuid.UUID,
@@ -66,7 +66,7 @@ async def generate_story(
 async def get_story_history(
     project_id: uuid.UUID,
     story_id: uuid.UUID,
-    user_id: Annotated[str, Depends(get_current_user_id)],
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     service: Annotated[StoryService, Depends(get_story_service)],
     limit: int = 20,
 ) -> list[EditEventResponseSchema]:

--- a/backend/core/story_engine/repository/character_repository.py
+++ b/backend/core/story_engine/repository/character_repository.py
@@ -35,7 +35,7 @@ class CharacterRepository:
 
     async def get_character_for_user_in_project_and_story(
         self,
-        user_id: str,
+        user_id: uuid.UUID,
         project_id: uuid.UUID,
         story_id: uuid.UUID,
         character_id: uuid.UUID,
@@ -48,7 +48,7 @@ class CharacterRepository:
                 Character.id == character_id,
                 Story.id == story_id,
                 Project.id == project_id,
-                Project.user_id == uuid.UUID(user_id),
+                Project.user_id == user_id,
             )
         )
         result = await self.db.execute(stmt)

--- a/backend/core/story_engine/repository/project_repository.py
+++ b/backend/core/story_engine/repository/project_repository.py
@@ -12,29 +12,31 @@ class ProjectRepository:
         self.db = db
 
     async def get_all_projects_of_user_with_story_count(
-        self, user_id: str
+        self, user_id: uuid.UUID
     ) -> list[tuple[Project, int]]:
         query = (
             select(Project, func.count(Story.id).label("story_count"))
             .outerjoin(Story, Story.project_id == Project.id)
-            .where(Project.user_id == uuid.UUID(user_id))
+            .where(Project.user_id == user_id)
             .group_by(Project.id)
         )
         result = await self.db.execute(query)
         projects = result.tuples().all()
         return list(projects)
 
-    async def create_project(self, user_id: str, name: str | None = None) -> Project:
-        project = Project(user_id=uuid.UUID(user_id), name=name)
+    async def create_project(
+        self, user_id: uuid.UUID, name: str | None = None
+    ) -> Project:
+        project = Project(user_id=user_id, name=name)
         self.db.add(project)
         return project
 
     async def get_project_details(
-        self, user_id: str, project_id: uuid.UUID
+        self, user_id: uuid.UUID, project_id: uuid.UUID
     ) -> Project | None:
         query = (
             select(Project)
-            .where(Project.id == project_id, Project.user_id == uuid.UUID(user_id))
+            .where(Project.id == project_id, Project.user_id == user_id)
             .options(
                 selectinload(Project.stories),
             )

--- a/backend/core/story_engine/service/character_service.py
+++ b/backend/core/story_engine/service/character_service.py
@@ -373,7 +373,7 @@ class CharacterService:
 
     async def upload_reference_image(
         self,
-        user_id: str,
+        user_id: uuid.UUID,
         project_id: uuid.UUID,
         story_id: uuid.UUID,
         character_id: uuid.UUID,

--- a/backend/core/story_engine/service/image_service.py
+++ b/backend/core/story_engine/service/image_service.py
@@ -58,7 +58,7 @@ class ImageService:
 
     async def upload_reference_image(
         self,
-        user_id: str,
+        user_id: uuid.UUID,
         project_id: uuid.UUID,
         story_id: uuid.UUID,
         character_id: uuid.UUID,
@@ -93,7 +93,7 @@ class ImageService:
             )
             image_model = ImageModel.create_image_model(
                 project_id=project_id,
-                user_id=uuid.UUID(user_id),
+                user_id=user_id,
                 character_id=character_id,
                 width=processed_image.width,
                 height=processed_image.height,
@@ -119,7 +119,7 @@ class ImageService:
 
     async def get_character_reference_images(
         self,
-        user_id: str,
+        user_id: uuid.UUID,
         project_id: uuid.UUID,
         story_id: uuid.UUID,
         character_id: uuid.UUID,
@@ -134,17 +134,17 @@ class ImageService:
     async def get_signed_url(
         self,
         image_id: uuid.UUID,
-        user_id: str,
+        user_id: uuid.UUID,
     ) -> tuple[str, datetime.datetime]:
         image = await self.repository_v2.image.get_image(image_id)
-        if image is None or str(image.user_id) != user_id:
+        if image is None or image.user_id != user_id:
             raise NotFoundError(f"Image {image_id} not found")
         url, expires_at = self.gcs_upload_service.generate_signed_url(image.object_key)
         return url, expires_at
 
     async def _get_authorized_character(
         self,
-        user_id: str,
+        user_id: uuid.UUID,
         project_id: uuid.UUID,
         story_id: uuid.UUID,
         character_id: uuid.UUID,

--- a/backend/core/story_engine/service/project_service.py
+++ b/backend/core/story_engine/service/project_service.py
@@ -11,14 +11,18 @@ class ProjectService:
         self.db = db_session
         self.repository_v2 = RepositoryV2(db_session)
 
-    async def get_all_projects_of_user(self, user_id: str) -> list[tuple[Project, int]]:
+    async def get_all_projects_of_user(
+        self, user_id: uuid.UUID
+    ) -> list[tuple[Project, int]]:
         return (
             await self.repository_v2.project.get_all_projects_of_user_with_story_count(
                 user_id
             )
         )
 
-    async def create_project(self, user_id: str, name: str | None = None) -> Project:
+    async def create_project(
+        self, user_id: uuid.UUID, name: str | None = None
+    ) -> Project:
         project = await self.repository_v2.project.create_project(
             user_id=user_id, name=name
         )
@@ -27,7 +31,7 @@ class ProjectService:
         return project
 
     async def get_project_details(
-        self, user_id: str, project_id: uuid.UUID
+        self, user_id: uuid.UUID, project_id: uuid.UUID
     ) -> Project | None:
         return await self.repository_v2.project.get_project_details(user_id, project_id)
 

--- a/backend/core/story_engine/service/story_service.py
+++ b/backend/core/story_engine/service/story_service.py
@@ -10,7 +10,6 @@ from core.services.intelligence.clients import async_openai_client
 
 from ..events import ErrorPayload, EventEnvelope, EventType
 from ..exceptions import (
-    InvalidUserIDError,
     NotFoundError,
     NotOwnedError,
     StreamGeneratorError,
@@ -104,13 +103,6 @@ class StoryService:
         self.stream_generator = stream_generator or StoryStreamGenerator()
         self.processor = processor or OpenAIStreamProcessor()
 
-    def _get_user_id(self, user_id: str) -> uuid.UUID:
-        """Convert user ID string to UUID."""
-        try:
-            return uuid.UUID(user_id)
-        except ValueError as e:
-            raise InvalidUserIDError(f"Invalid user ID: {user_id}") from e
-
     async def _check_story_ownership(
         self, _user_id: uuid.UUID, story_with_project: Story
     ) -> None:
@@ -146,20 +138,18 @@ class StoryService:
 
     async def generate_story(
         self,
-        user_id: str,
+        user_id: uuid.UUID,
         project_id: uuid.UUID,
         story_id: uuid.UUID,
         request: GenerateStoryRequest,
     ) -> AsyncIterator[EventEnvelope]:
-        _user_id = self._get_user_id(user_id)
-
         story_with_project = await self.repository_v2.story.get_story_with_project(
             story_id
         )
         if story_with_project is None:
             raise NotFoundError(f"Story {story_id} not found")
 
-        await self._check_story_ownership(_user_id, story_with_project)
+        await self._check_story_ownership(user_id, story_with_project)
 
         prev_story_text = story_with_project.story_text
 

--- a/backend/tests/story_engine/test_image_upload_service.py
+++ b/backend/tests/story_engine/test_image_upload_service.py
@@ -96,7 +96,7 @@ async def test_upload_reference_image_via_service(
     service = ImageService(db=db_session, repository_v2=repo)
 
     await service.upload_reference_image(
-        user_id=str(user.id),
+        user_id=user.id,
         project_id=project.id,
         story_id=story.id,
         character_id=character.id,
@@ -283,7 +283,7 @@ async def test_get_character_reference_images_via_endpoint(
 
     # Upload one reference image directly via service
     uploaded = await service.upload_reference_image(
-        user_id=str(user.id),
+        user_id=user.id,
         project_id=project.id,
         story_id=story.id,
         character_id=character.id,


### PR DESCRIPTION
## Summary

- `JWTTokenManager.extract_user_id_from_access_token` now returns `uuid.UUID` instead of `str`, converting the JWT `sub` claim string internally and raising `InvalidTokenError` on a malformed UUID — single place, single responsibility
- All downstream signatures updated to `uuid.UUID`: FastAPI dependency, socket handler, session/user managers, all API handlers, all services, all repositories
- Removes every inline `uuid.UUID(user_id)` conversion call site across the codebase (13 sites eliminated), the `str(image.user_id) != user_id` backwards comparison, and the now-unnecessary `_get_user_id` helper in `StoryService`

## Files changed (20)

| Layer | Files |
|---|---|
| JWT / auth core | `jwt.py`, `dependencies.py`, `session.py`, `user.py`, `router.py` |
| Socket handler | `sockets/handlers.py` |
| API handlers | `api/dependencies.py`, `api/projects.py`, `api/phases.py`, `api/v2/projects.py`, `api/v2/story.py`, `api/v2/character.py`, `api/v2/images.py` |
| Services | `project_service.py`, `story_service.py`, `image_service.py`, `character_service.py` |
| Repositories | `project_repository.py`, `character_repository.py` |
| Tests | `test_image_upload_service.py` |

No database migrations required — all models already stored `user_id` as native UUID.