### PR TITLE
test: add API v2 test suite and fix bugs uncovered by tests

### DIFF
--- a/backend/core/story_engine/api/v2/character.py
+++ b/backend/core/story_engine/api/v2/character.py
@@ -54,6 +54,7 @@ async def extract_characters_from_story(
 async def get_characters_for_story(
     project_id: uuid.UUID,
     story_id: uuid.UUID,
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     service: Annotated[CharacterService, Depends(get_character_service)],
 ) -> list[CharacterResponseSchema]:
     try:
@@ -171,6 +172,7 @@ async def get_character_history(
     project_id: uuid.UUID,
     story_id: uuid.UUID,
     character_id: uuid.UUID,
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     service: Annotated[CharacterService, Depends(get_character_service)],
     limit: int = 20,
 ) -> list[EditEventResponseSchema]:

--- a/backend/core/story_engine/api/v2/projects.py
+++ b/backend/core/story_engine/api/v2/projects.py
@@ -73,7 +73,7 @@ async def create_story(
     return StoryResponseSchema.model_validate(story)
 
 
-@router.delete("/projects/{project_id}/story/{story_id}")
+@router.delete("/projects/{project_id}/story/{story_id}", status_code=204)
 async def delete_story(
     project_id: uuid.UUID,
     story_id: uuid.UUID,

--- a/backend/core/story_engine/service/project_service.py
+++ b/backend/core/story_engine/service/project_service.py
@@ -2,8 +2,10 @@ import uuid
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from ..exceptions import NotFoundError
 from ..models import Project, Story
 from ..repository import RepositoryV2
+from ..repository.exception import NotFoundError as RepoNotFoundError
 
 
 class ProjectService:
@@ -42,5 +44,8 @@ class ProjectService:
         return story
 
     async def delete_story(self, project_id: uuid.UUID, story_id: uuid.UUID) -> None:
-        await self.repository_v2.story.delete_story(project_id, story_id)
+        try:
+            await self.repository_v2.story.delete_story(project_id, story_id)
+        except RepoNotFoundError as e:
+            raise NotFoundError(str(e)) from e
         await self.db.commit()

--- a/backend/tests/story_engine/test_character_list_history_api.py
+++ b/backend/tests/story_engine/test_character_list_history_api.py
@@ -1,0 +1,457 @@
+"""
+API tests for character list and history endpoints (v2).
+
+GET  /api/comic-builder/v2/project/{project_id}/story/{story_id}/characters
+GET  /api/comic-builder/v2/project/{project_id}/story/{story_id}/character/{character_id}/history
+
+The extract (POST …/characters) and refine (POST …/character/{id}/refine)
+endpoints require OpenAI and are covered by manual smoke tests.
+
+Invariants under test:
+- Response shape: camelCase, required fields, correct types
+- Empty list before any characters exist
+- History is empty before any edit events, ordered correctly after
+- Auth boundary: 401 without token
+- 404 when story or project doesn't exist
+
+No mocking. Real FastAPI app, real Postgres.
+"""
+
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.auth.managers.jwt import JWTTokenManager
+from core.auth.models.user import User
+from core.story_engine.models import Character, Project, Story
+from core.story_engine.models.edit_event import (
+    EditEvent,
+    EditEventOperationType,
+    EditEventStatus,
+    EditEventTargetType,
+)
+
+_jwt = JWTTokenManager()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _auth_headers(user_id: uuid.UUID) -> dict[str, str]:
+    token = _jwt.create_access_token(user_id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _characters_url(project_id: uuid.UUID, story_id: uuid.UUID) -> str:
+    return f"/api/comic-builder/v2/project/{project_id}/story/{story_id}/characters"
+
+
+def _character_history_url(
+    project_id: uuid.UUID, story_id: uuid.UUID, character_id: uuid.UUID
+) -> str:
+    return (
+        f"/api/comic-builder/v2/project/{project_id}"
+        f"/story/{story_id}"
+        f"/character/{character_id}/history"
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /project/{project_id}/story/{story_id}/characters
+# ---------------------------------------------------------------------------
+
+
+async def test_list_characters_returns_200(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+) -> None:
+    """The characters list endpoint returns 200."""
+    response = await api_client.get(
+        _characters_url(project.id, story.id),
+        headers=_auth_headers(user.id),
+    )
+    assert response.status_code == 200
+
+
+async def test_list_characters_returns_array(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+) -> None:
+    """The response is a JSON array."""
+    response = await api_client.get(
+        _characters_url(project.id, story.id),
+        headers=_auth_headers(user.id),
+    )
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+async def test_list_characters_contains_fixture_character(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+) -> None:
+    """The fixture character appears in the list."""
+    response = await api_client.get(
+        _characters_url(project.id, story.id),
+        headers=_auth_headers(user.id),
+    )
+
+    ids = [c["id"] for c in response.json()]
+    assert str(character.id) in ids
+
+
+async def test_list_characters_response_shape(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+) -> None:
+    """Each character item matches CharacterResponseSchema.
+
+    Renaming or removing fields (e.g. slug → identifier) should fail here.
+    """
+    response = await api_client.get(
+        _characters_url(project.id, story.id),
+        headers=_auth_headers(user.id),
+    )
+
+    assert response.status_code == 200
+    item = next(c for c in response.json() if c["id"] == str(character.id))
+
+    # Core identity fields
+    assert "id" in item
+    assert "name" in item
+    assert "slug" in item
+    assert "attributes" in item
+    assert isinstance(item["attributes"], dict)
+
+    # Audit / relation fields
+    assert "sourceEventId" in item
+    assert "renderUrl" in item
+    assert "createdAt" in item
+    assert "updatedAt" in item
+    assert "meta" in item
+
+
+async def test_list_characters_attributes_content(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+) -> None:
+    """The attributes dict carries the values stored in the fixture."""
+    response = await api_client.get(
+        _characters_url(project.id, story.id),
+        headers=_auth_headers(user.id),
+    )
+
+    item = next(c for c in response.json() if c["id"] == str(character.id))
+    attrs = item["attributes"]
+
+    assert attrs["name"] == "Aragorn"
+    assert attrs["character_type"] == "protagonist"
+    assert attrs["demeanor"] == "Stoic and resolute"
+
+
+async def test_list_characters_empty_for_story_without_characters(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    db_session: AsyncSession,
+) -> None:
+    """A story that has no characters returns an empty list."""
+    from core.story_engine.models import Story as StoryModel
+
+    bare_story = StoryModel(project_id=project.id, story_text="no characters yet")
+    db_session.add(bare_story)
+    await db_session.commit()
+    await db_session.refresh(bare_story)
+
+    response = await api_client.get(
+        _characters_url(project.id, bare_story.id),
+        headers=_auth_headers(user.id),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+    # Cleanup (cascade from project will handle it but be explicit)
+    from sqlalchemy import text
+
+    await db_session.execute(
+        text("DELETE FROM story WHERE id = :id"), {"id": bare_story.id}
+    )
+    await db_session.commit()
+
+
+async def test_list_characters_multiple_characters(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+    db_session: AsyncSession,
+) -> None:
+    """When a story has multiple characters all of them appear in the list."""
+    from core.story_engine.models import Character as CharacterModel
+
+    second = CharacterModel(
+        story_id=story.id,
+        name="Legolas",
+        slug="legolas",
+        attributes={"name": "Legolas", "character_type": "ally"},
+    )
+    db_session.add(second)
+    await db_session.commit()
+    await db_session.refresh(second)
+
+    response = await api_client.get(
+        _characters_url(project.id, story.id),
+        headers=_auth_headers(user.id),
+    )
+
+    assert response.status_code == 200
+    ids = {c["id"] for c in response.json()}
+    assert str(character.id) in ids
+    assert str(second.id) in ids
+
+    # Cleanup second character (cascade would get it, but explicit is cleaner)
+    from sqlalchemy import text
+
+    await db_session.execute(
+        text("DELETE FROM character WHERE id = :id"), {"id": second.id}
+    )
+    await db_session.commit()
+
+
+async def test_list_characters_404_unknown_story(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+) -> None:
+    """Listing characters for a non-existent story returns 404."""
+    response = await api_client.get(
+        _characters_url(project.id, uuid.uuid4()),
+        headers=_auth_headers(user.id),
+    )
+    assert response.status_code == 404
+
+
+async def test_list_characters_requires_auth(
+    api_client: AsyncClient,
+    project: Project,
+    story: Story,
+) -> None:
+    """GET characters without a token returns 401."""
+    response = await api_client.get(_characters_url(project.id, story.id))
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /project/{project_id}/story/{story_id}/character/{character_id}/history
+# ---------------------------------------------------------------------------
+
+
+async def test_character_history_empty_for_new_character(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+) -> None:
+    """A freshly created character has no history events."""
+    response = await api_client.get(
+        _character_history_url(project.id, story.id, character.id),
+        headers=_auth_headers(user.id),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_character_history_returns_events_after_operation(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+    db_session: AsyncSession,
+) -> None:
+    """After inserting a refinement event, the history endpoint returns it."""
+    event = EditEvent.create_edit_event(
+        project_id=project.id,
+        target_type=EditEventTargetType.CHARACTER,
+        target_id=character.id,
+        operation_type=EditEventOperationType.REFINE_CHARACTER,
+        user_instruction="make him older",
+        status=EditEventStatus.SUCCEEDED,
+        output_snapshot={"name": "Aragorn", "era": "Fourth Age"},
+    )
+    db_session.add(event)
+    await db_session.commit()
+
+    response = await api_client.get(
+        _character_history_url(project.id, story.id, character.id),
+        headers=_auth_headers(user.id),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body, list)
+    assert len(body) >= 1
+
+    entry = next((e for e in body if e["targetId"] == str(character.id)), None)
+    assert entry is not None
+
+
+async def test_character_history_event_shape(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+    db_session: AsyncSession,
+) -> None:
+    """Each history entry has all EditEventResponseSchema fields.
+
+    If the schema drops a field this test breaks.
+    """
+    event = EditEvent.create_edit_event(
+        project_id=project.id,
+        target_type=EditEventTargetType.CHARACTER,
+        target_id=character.id,
+        operation_type=EditEventOperationType.REFINE_CHARACTER,
+        user_instruction="shape-check instruction",
+        status=EditEventStatus.SUCCEEDED,
+    )
+    db_session.add(event)
+    await db_session.commit()
+
+    response = await api_client.get(
+        _character_history_url(project.id, story.id, character.id),
+        headers=_auth_headers(user.id),
+    )
+
+    assert response.status_code == 200
+    entry = response.json()[0]
+
+    assert "id" in entry
+    assert "projectId" in entry
+    assert "targetType" in entry
+    assert entry["targetType"] == "character"
+    assert "targetId" in entry
+    assert "operationType" in entry
+    assert "userInstruction" in entry
+    assert "status" in entry
+    assert "createdAt" in entry
+    assert "outputSnapshot" in entry
+
+
+async def test_character_history_only_returns_this_characters_events(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+    db_session: AsyncSession,
+) -> None:
+    """Events for a different character do not bleed into the history response."""
+    from core.story_engine.models import Character as CharacterModel
+
+    other = CharacterModel(
+        story_id=story.id,
+        name="Gimli",
+        slug="gimli",
+        attributes={"name": "Gimli"},
+    )
+    db_session.add(other)
+    await db_session.commit()
+    await db_session.refresh(other)
+
+    # Add an event for the OTHER character
+    other_event = EditEvent.create_edit_event(
+        project_id=project.id,
+        target_type=EditEventTargetType.CHARACTER,
+        target_id=other.id,
+        operation_type=EditEventOperationType.REFINE_CHARACTER,
+        user_instruction="make him stockier",
+        status=EditEventStatus.SUCCEEDED,
+    )
+    db_session.add(other_event)
+    await db_session.commit()
+
+    # History for the fixture character should be empty
+    response = await api_client.get(
+        _character_history_url(project.id, story.id, character.id),
+        headers=_auth_headers(user.id),
+    )
+
+    assert response.status_code == 200
+    target_ids = {e["targetId"] for e in response.json()}
+    assert str(other.id) not in target_ids
+
+    # Cleanup
+    from sqlalchemy import text
+
+    await db_session.execute(
+        text("DELETE FROM character WHERE id = :id"), {"id": other.id}
+    )
+    await db_session.commit()
+
+
+async def test_character_history_requires_auth(
+    api_client: AsyncClient,
+    project: Project,
+    story: Story,
+    character: Character,
+) -> None:
+    """GET character history without a token returns 401."""
+    response = await api_client.get(
+        _character_history_url(project.id, story.id, character.id)
+    )
+    assert response.status_code == 401
+
+
+async def test_character_history_limit_param(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+    db_session: AsyncSession,
+) -> None:
+    """The `limit` query param caps the number of events returned."""
+    for i in range(5):
+        event = EditEvent.create_edit_event(
+            project_id=project.id,
+            target_type=EditEventTargetType.CHARACTER,
+            target_id=character.id,
+            operation_type=EditEventOperationType.REFINE_CHARACTER,
+            user_instruction=f"refinement {i}",
+            status=EditEventStatus.SUCCEEDED,
+        )
+        db_session.add(event)
+    await db_session.commit()
+
+    response = await api_client.get(
+        _character_history_url(project.id, story.id, character.id),
+        headers=_auth_headers(user.id),
+        params={"limit": 3},
+    )
+
+    assert response.status_code == 200
+    assert len(response.json()) <= 3

--- a/backend/tests/story_engine/test_character_refine_smoke.py
+++ b/backend/tests/story_engine/test_character_refine_smoke.py
@@ -11,6 +11,7 @@ from httpx import AsyncClient
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from core.auth.managers.jwt import JWTTokenManager
 from core.story_engine.models import Character, EditEvent
 from core.story_engine.models.edit_event import (
     EditEventOperationType,
@@ -23,6 +24,11 @@ from core.story_engine.schemas.character import CharacterResponseSchema
 PROJECT_ID = "9c10291d-4b0a-4c2f-8deb-417d36a12d7b"
 STORY_ID = "0a358afa-670c-4729-b1d3-838a76320993"
 CHARACTER_ID = "61c317cf-06c9-4d95-bd06-6d9518a4eeba"
+USER_ID = "2c2af68f-9315-4bab-8aa3-3b1a581dca8e"  # owner of the project above
+
+_AUTH_HEADERS = {
+    "Authorization": f"Bearer {JWTTokenManager().create_access_token(USER_ID)}"
+}
 
 
 @pytest.mark.manual
@@ -46,6 +52,7 @@ async def test_refine_character_smoke_existing_row(
         f"/story/{STORY_ID}"
         f"/character/{CHARACTER_ID}/refine",
         json={"instruction": test_instruction},
+        headers=_AUTH_HEADERS,
     )
 
     assert response.status_code == 200
@@ -79,21 +86,25 @@ async def test_get_existing_character_edit_history(
 ) -> None:
     possible_operation_types = [
         EditEventOperationType.REFINE_CHARACTER,
+        EditEventOperationType.UPLOAD_REFERENCE_IMAGE,
     ]
 
     response = await api_client.get(
         f"/api/comic-builder/v2/project/{PROJECT_ID}"
         f"/story/{STORY_ID}"
         f"/character/{CHARACTER_ID}/history",
+        headers=_AUTH_HEADERS,
     )
 
     assert response.status_code == 200
     body = response.json()
     assert len(body) >= 1
+    instruction_required_operations = {EditEventOperationType.REFINE_CHARACTER}
     for event in body:
         assert str(event["targetId"]) == CHARACTER_ID
         assert event["operationType"] in possible_operation_types
-        assert event["userInstruction"] != ""
+        if event["operationType"] in instruction_required_operations:
+            assert event["userInstruction"] != ""
         assert event["status"] in [
             EditEventStatus.SUCCEEDED,
             EditEventStatus.FAILED,
@@ -117,6 +128,7 @@ async def test_render_existing_character(
         f"/api/comic-builder/v2/project/{PROJECT_ID}"
         f"/story/{STORY_ID}"
         f"/character/{CHARACTER_ID}/render",
+        headers=_AUTH_HEADERS,
     )
 
     assert response.status_code == 200

--- a/backend/tests/story_engine/test_projects_api.py
+++ b/backend/tests/story_engine/test_projects_api.py
@@ -1,0 +1,599 @@
+"""
+API tests for project and story management endpoints (v2).
+
+GET    /api/comic-builder/v2/projects
+POST   /api/comic-builder/v2/projects
+GET    /api/comic-builder/v2/projects/{project_id}
+POST   /api/comic-builder/v2/projects/{project_id}/story
+DELETE /api/comic-builder/v2/projects/{project_id}/story/{story_id}
+
+Invariants under test:
+- Response shapes (camelCase serialisation, required fields, field types)
+- DB side-effects (rows created / deleted)
+- Auth boundary: 401 without a token on every endpoint
+- 404 for missing resources
+- Ownership isolation: a user cannot see another user's projects
+
+No mocking. Real FastAPI app, real Postgres.
+"""
+
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.auth.managers.jwt import JWTTokenManager
+from core.auth.models.user import User
+from core.story_engine.models import Project, Story
+
+_jwt = JWTTokenManager()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _auth_headers(user_id: uuid.UUID) -> dict[str, str]:
+    token = _jwt.create_access_token(user_id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _projects_url() -> str:
+    return "/api/comic-builder/v2/projects"
+
+
+def _project_url(project_id: uuid.UUID) -> str:
+    return f"/api/comic-builder/v2/projects/{project_id}"
+
+
+def _stories_url(project_id: uuid.UUID) -> str:
+    return f"/api/comic-builder/v2/projects/{project_id}/story"
+
+
+def _story_url(project_id: uuid.UUID, story_id: uuid.UUID) -> str:
+    return f"/api/comic-builder/v2/projects/{project_id}/story/{story_id}"
+
+
+# ---------------------------------------------------------------------------
+# GET /projects — list all projects for user
+# ---------------------------------------------------------------------------
+
+
+async def test_list_projects_returns_200_and_array(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+) -> None:
+    """The listing endpoint returns an array containing the fixture project."""
+    response = await api_client.get(_projects_url(), headers=_auth_headers(user.id))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body, list)
+
+    ids = [item["id"] for item in body]
+    assert str(project.id) in ids
+
+
+async def test_list_projects_response_shape(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+) -> None:
+    """Each item in the list has the fields from ProjectListResponseSchema.
+
+    Renaming or removing a field should fail this test.
+    """
+    response = await api_client.get(_projects_url(), headers=_auth_headers(user.id))
+
+    assert response.status_code == 200
+    item = next(i for i in response.json() if i["id"] == str(project.id))
+
+    assert "id" in item
+    assert "name" in item
+    assert "createdAt" in item
+    assert "updatedAt" in item
+    assert "storyCount" in item
+    assert isinstance(item["storyCount"], int)
+
+
+async def test_list_projects_story_count_reflects_stories(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+) -> None:
+    """storyCount in the list reflects the number of stories under the project."""
+    response = await api_client.get(_projects_url(), headers=_auth_headers(user.id))
+
+    item = next(i for i in response.json() if i["id"] == str(project.id))
+    assert item["storyCount"] >= 1
+
+
+async def test_list_projects_empty_for_new_user(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A brand new user with no projects gets an empty list."""
+    unique_email = f"empty-list-{uuid.uuid4()}@example.com"
+    from core.auth.models.user import User as UserModel
+
+    new_user = UserModel(email=unique_email, password_hash="not-a-hash")
+    db_session.add(new_user)
+    await db_session.commit()
+    await db_session.refresh(new_user)
+
+    response = await api_client.get(_projects_url(), headers=_auth_headers(new_user.id))
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+    await db_session.execute(
+        text('DELETE FROM "user" WHERE id = :id'), {"id": new_user.id}
+    )
+    await db_session.commit()
+
+
+async def test_list_projects_requires_auth(
+    api_client: AsyncClient,
+) -> None:
+    """GET /projects without a token returns 401."""
+    response = await api_client.get(_projects_url())
+    assert response.status_code == 401
+
+
+async def test_list_projects_does_not_return_other_users_projects(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    user: User,
+    project: Project,
+) -> None:
+    """A second user cannot see the first user's projects."""
+    other_email = f"other-{uuid.uuid4()}@example.com"
+    from core.auth.models.user import User as UserModel
+
+    other_user = UserModel(email=other_email, password_hash="not-a-hash")
+    db_session.add(other_user)
+    await db_session.commit()
+    await db_session.refresh(other_user)
+
+    response = await api_client.get(
+        _projects_url(), headers=_auth_headers(other_user.id)
+    )
+
+    assert response.status_code == 200
+    ids = [item["id"] for item in response.json()]
+    assert str(project.id) not in ids
+
+    await db_session.execute(
+        text('DELETE FROM "user" WHERE id = :id'), {"id": other_user.id}
+    )
+    await db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# POST /projects — create a project
+# ---------------------------------------------------------------------------
+
+
+async def test_create_project_returns_201_and_id(
+    api_client: AsyncClient,
+    user: User,
+    db_session: AsyncSession,
+) -> None:
+    """Creating a project returns 200 with the new project's ID."""
+    response = await api_client.post(
+        _projects_url(),
+        headers=_auth_headers(user.id),
+        json={"name": "My Test Project"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "id" in body
+    project_id = uuid.UUID(body["id"])
+
+    # Verify the row actually exists in the DB
+    result = await db_session.execute(
+        text("SELECT id FROM project WHERE id = :id"), {"id": project_id}
+    )
+    assert result.fetchone() is not None
+
+    # Cleanup (cascade will handle it, but we tidy up explicitly)
+    await db_session.execute(
+        text("DELETE FROM project WHERE id = :id"), {"id": project_id}
+    )
+    await db_session.commit()
+
+
+async def test_create_project_persists_name(
+    api_client: AsyncClient,
+    user: User,
+    db_session: AsyncSession,
+) -> None:
+    """The name supplied at creation is stored and returned."""
+    response = await api_client.post(
+        _projects_url(),
+        headers=_auth_headers(user.id),
+        json={"name": "Named Project"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "Named Project"
+
+    await db_session.execute(
+        text("DELETE FROM project WHERE id = :id"), {"id": uuid.UUID(body["id"])}
+    )
+    await db_session.commit()
+
+
+async def test_create_project_response_shape(
+    api_client: AsyncClient,
+    user: User,
+    db_session: AsyncSession,
+) -> None:
+    """The create-project response matches ProjectResponseSchema fields.
+
+    Adding or removing fields should surface here.
+    """
+    response = await api_client.post(
+        _projects_url(),
+        headers=_auth_headers(user.id),
+        json={"name": "Shape Test"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+
+    assert "id" in body
+    assert "name" in body
+    assert "createdAt" in body
+    assert "updatedAt" in body
+    assert "state" in body  # legacy state blob — must still be present
+
+    await db_session.execute(
+        text("DELETE FROM project WHERE id = :id"), {"id": uuid.UUID(body["id"])}
+    )
+    await db_session.commit()
+
+
+async def test_create_project_without_name(
+    api_client: AsyncClient,
+    user: User,
+    db_session: AsyncSession,
+) -> None:
+    """Name is optional — omitting it returns 200 and null name."""
+    response = await api_client.post(
+        _projects_url(),
+        headers=_auth_headers(user.id),
+        json={},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] is None
+
+    await db_session.execute(
+        text("DELETE FROM project WHERE id = :id"), {"id": uuid.UUID(body["id"])}
+    )
+    await db_session.commit()
+
+
+async def test_create_project_requires_auth(
+    api_client: AsyncClient,
+) -> None:
+    """POST /projects without a token returns 401."""
+    response = await api_client.post(_projects_url(), json={"name": "Unauthorized"})
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /projects/{project_id} — project details with stories
+# ---------------------------------------------------------------------------
+
+
+async def test_get_project_returns_200(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+) -> None:
+    """Fetching an existing project by ID returns 200."""
+    response = await api_client.get(
+        _project_url(project.id), headers=_auth_headers(user.id)
+    )
+    assert response.status_code == 200
+
+
+async def test_get_project_response_shape(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+) -> None:
+    """ProjectRelationalStateSchema includes a nested stories array.
+
+    Removing the stories field or flattening the schema should fail here.
+    """
+    response = await api_client.get(
+        _project_url(project.id), headers=_auth_headers(user.id)
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+
+    assert body["id"] == str(project.id)
+    assert "stories" in body
+    assert isinstance(body["stories"], list)
+
+    story_ids = [s["id"] for s in body["stories"]]
+    assert str(story.id) in story_ids
+
+
+async def test_get_project_story_shape(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+) -> None:
+    """Nested story objects include the expected StoryResponseSchema fields."""
+    response = await api_client.get(
+        _project_url(project.id), headers=_auth_headers(user.id)
+    )
+
+    assert response.status_code == 200
+    nested_story = next(
+        s for s in response.json()["stories"] if s["id"] == str(story.id)
+    )
+
+    assert "id" in nested_story
+    assert "projectId" in nested_story
+    assert "storyText" in nested_story
+    assert "userInputText" in nested_story
+    assert "sourceEventId" in nested_story
+
+
+async def test_get_project_404_for_unknown_id(
+    api_client: AsyncClient,
+    user: User,
+) -> None:
+    """Fetching a project that doesn't exist returns 404."""
+    response = await api_client.get(
+        _project_url(uuid.uuid4()), headers=_auth_headers(user.id)
+    )
+    assert response.status_code == 404
+
+
+async def test_get_project_404_for_other_users_project(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    project: Project,
+) -> None:
+    """A different user cannot fetch another user's project by ID."""
+    from core.auth.models.user import User as UserModel
+
+    other_user = UserModel(
+        email=f"isolation-{uuid.uuid4()}@example.com", password_hash="x"
+    )
+    db_session.add(other_user)
+    await db_session.commit()
+    await db_session.refresh(other_user)
+
+    response = await api_client.get(
+        _project_url(project.id), headers=_auth_headers(other_user.id)
+    )
+    assert response.status_code == 404
+
+    await db_session.execute(
+        text('DELETE FROM "user" WHERE id = :id'), {"id": other_user.id}
+    )
+    await db_session.commit()
+
+
+async def test_get_project_requires_auth(
+    api_client: AsyncClient,
+    project: Project,
+) -> None:
+    """GET /projects/{id} without a token returns 401."""
+    response = await api_client.get(_project_url(project.id))
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /projects/{project_id}/story — create a story
+# ---------------------------------------------------------------------------
+
+
+async def test_create_story_returns_200_and_id(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    db_session: AsyncSession,
+) -> None:
+    """Creating a story under a project returns 200 with the new story's ID."""
+    response = await api_client.post(
+        _stories_url(project.id),
+        headers=_auth_headers(user.id),
+        json={"projectId": str(project.id)},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "id" in body
+    story_id = uuid.UUID(body["id"])
+
+    # Verify the row exists in the DB
+    result = await db_session.execute(
+        text("SELECT id FROM story WHERE id = :id"), {"id": story_id}
+    )
+    assert result.fetchone() is not None
+
+    # Cleanup (cascade from project handles it, but be explicit)
+    await db_session.execute(text("DELETE FROM story WHERE id = :id"), {"id": story_id})
+    await db_session.commit()
+
+
+async def test_create_story_response_shape(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    db_session: AsyncSession,
+) -> None:
+    """The create-story response matches StoryResponseSchema.
+
+    Changing the schema's field names or types surfaces here.
+    """
+    response = await api_client.post(
+        _stories_url(project.id),
+        headers=_auth_headers(user.id),
+        json={"projectId": str(project.id)},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+
+    assert "id" in body
+    assert "projectId" in body
+    assert body["projectId"] == str(project.id)
+    assert "storyText" in body
+    assert "userInputText" in body
+    assert "sourceEventId" in body
+    assert body["sourceEventId"] is None  # freshly created — no event yet
+
+    story_id = uuid.UUID(body["id"])
+    await db_session.execute(text("DELETE FROM story WHERE id = :id"), {"id": story_id})
+    await db_session.commit()
+
+
+async def test_create_story_story_text_starts_empty(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    db_session: AsyncSession,
+) -> None:
+    """A newly created story has empty story_text before any generation."""
+    response = await api_client.post(
+        _stories_url(project.id),
+        headers=_auth_headers(user.id),
+        json={"projectId": str(project.id)},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["storyText"] == ""
+
+    await db_session.execute(
+        text("DELETE FROM story WHERE id = :id"), {"id": uuid.UUID(body["id"])}
+    )
+    await db_session.commit()
+
+
+async def test_create_story_requires_auth(
+    api_client: AsyncClient,
+    project: Project,
+) -> None:
+    """POST /projects/{id}/story without a token returns 401."""
+    response = await api_client.post(
+        _stories_url(project.id),
+        json={"projectId": str(project.id)},
+    )
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# DELETE /projects/{project_id}/story/{story_id}
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_story_returns_204(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+) -> None:
+    """DELETE on an existing story returns 204 with no body."""
+    response = await api_client.delete(
+        _story_url(project.id, story.id),
+        headers=_auth_headers(user.id),
+    )
+
+    assert response.status_code == 204
+    assert response.content == b""
+
+
+async def test_delete_story_removes_row_from_db(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    db_session: AsyncSession,
+) -> None:
+    """After DELETE the story row is gone from the DB."""
+    # Create an extra story so we don't rely on the shared fixture
+    from core.story_engine.models import Story as StoryModel
+
+    extra = StoryModel(project_id=project.id, story_text="to be deleted")
+    db_session.add(extra)
+    await db_session.commit()
+    await db_session.refresh(extra)
+
+    response = await api_client.delete(
+        _story_url(project.id, extra.id),
+        headers=_auth_headers(user.id),
+    )
+    assert response.status_code == 204
+
+    result = await db_session.execute(
+        text("SELECT id FROM story WHERE id = :id"), {"id": extra.id}
+    )
+    assert result.fetchone() is None
+
+
+async def test_delete_story_then_project_details_excludes_it(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    db_session: AsyncSession,
+) -> None:
+    """After deleting a story it no longer appears in GET /projects/{id}."""
+    from core.story_engine.models import Story as StoryModel
+
+    extra = StoryModel(project_id=project.id, story_text="delete-me")
+    db_session.add(extra)
+    await db_session.commit()
+    await db_session.refresh(extra)
+
+    await api_client.delete(
+        _story_url(project.id, extra.id),
+        headers=_auth_headers(user.id),
+    )
+
+    details_resp = await api_client.get(
+        _project_url(project.id), headers=_auth_headers(user.id)
+    )
+    story_ids = [s["id"] for s in details_resp.json()["stories"]]
+    assert str(extra.id) not in story_ids
+
+
+async def test_delete_story_404_unknown_story(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+) -> None:
+    """DELETE on a non-existent story ID returns 404."""
+    response = await api_client.delete(
+        _story_url(project.id, uuid.uuid4()),
+        headers=_auth_headers(user.id),
+    )
+    assert response.status_code == 404
+
+
+async def test_delete_story_requires_auth(
+    api_client: AsyncClient,
+    project: Project,
+    story: Story,
+) -> None:
+    """DELETE /projects/{id}/story/{id} without a token returns 401."""
+    response = await api_client.delete(_story_url(project.id, story.id))
+    assert response.status_code == 401

--- a/backend/tests/story_engine/test_story_api.py
+++ b/backend/tests/story_engine/test_story_api.py
@@ -1,0 +1,308 @@
+"""
+API tests for story endpoints (v2).
+
+GET  /api/comic-builder/v2/project/{project_id}/story/{story_id}
+GET  /api/comic-builder/v2/project/{project_id}/story/{story_id}/history
+
+The generate endpoint (POST …/generate) calls OpenAI and returns an NDJSON
+stream — that path is covered by manual/integration smoke tests.  Here we
+test only the non-LLM surfaces:
+
+Invariants under test:
+- Response shapes (camelCase, required fields, types)
+- 404 for unknown story or wrong project
+- Auth boundary: 401 without a token
+- History endpoint returns an empty list when no edit events exist
+
+No mocking. Real FastAPI app, real Postgres.
+"""
+
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.auth.managers.jwt import JWTTokenManager
+from core.auth.models.user import User
+from core.story_engine.models import Project, Story
+from core.story_engine.models.edit_event import (
+    EditEvent,
+    EditEventOperationType,
+    EditEventStatus,
+    EditEventTargetType,
+)
+
+_jwt = JWTTokenManager()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _auth_headers(user_id: uuid.UUID) -> dict[str, str]:
+    token = _jwt.create_access_token(user_id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _story_url(project_id: uuid.UUID, story_id: uuid.UUID) -> str:
+    return f"/api/comic-builder/v2/project/{project_id}/story/{story_id}"
+
+
+def _history_url(project_id: uuid.UUID, story_id: uuid.UUID) -> str:
+    return f"/api/comic-builder/v2/project/{project_id}/story/{story_id}/history"
+
+
+# ---------------------------------------------------------------------------
+# GET /project/{project_id}/story/{story_id}
+# ---------------------------------------------------------------------------
+
+
+async def test_get_story_returns_200(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+) -> None:
+    """Fetching an existing story returns 200."""
+    response = await api_client.get(
+        _story_url(project.id, story.id),
+        headers=_auth_headers(user.id),
+    )
+    assert response.status_code == 200
+
+
+async def test_get_story_response_shape(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+) -> None:
+    """The story response contains all StoryResponseSchema fields.
+
+    If the schema changes (field renames, removals), this test catches it.
+    """
+    response = await api_client.get(
+        _story_url(project.id, story.id),
+        headers=_auth_headers(user.id),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+
+    assert body["id"] == str(story.id)
+    assert body["projectId"] == str(project.id)
+    assert "storyText" in body
+    assert "userInputText" in body
+    assert "sourceEventId" in body
+    assert "meta" in body
+
+
+async def test_get_story_text_matches_fixture(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+) -> None:
+    """The returned storyText matches what was stored in the fixture."""
+    response = await api_client.get(
+        _story_url(project.id, story.id),
+        headers=_auth_headers(user.id),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["storyText"] == story.story_text
+
+
+async def test_get_story_source_event_null_before_generation(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+) -> None:
+    """A story that has never been generated has sourceEventId = null."""
+    response = await api_client.get(
+        _story_url(project.id, story.id),
+        headers=_auth_headers(user.id),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["sourceEventId"] is None
+
+
+async def test_get_story_404_wrong_story_id(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,  # ensures project row exists
+) -> None:
+    """A non-existent story ID returns 404."""
+    response = await api_client.get(
+        _story_url(project.id, uuid.uuid4()),
+        headers=_auth_headers(user.id),
+    )
+    assert response.status_code == 404
+
+
+async def test_get_story_404_wrong_project_id(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+) -> None:
+    """A story under the wrong project ID returns 404."""
+    response = await api_client.get(
+        _story_url(uuid.uuid4(), story.id),
+        headers=_auth_headers(user.id),
+    )
+    assert response.status_code == 404
+
+
+async def test_get_story_requires_auth(
+    api_client: AsyncClient,
+    project: Project,
+    story: Story,
+) -> None:
+    """GET story without a token returns 401."""
+    response = await api_client.get(_story_url(project.id, story.id))
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /project/{project_id}/story/{story_id}/history
+# ---------------------------------------------------------------------------
+
+
+async def test_get_story_history_returns_empty_list_when_no_events(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+) -> None:
+    """A fresh story has no edit events — the history endpoint returns []."""
+    response = await api_client.get(
+        _history_url(project.id, story.id),
+        headers=_auth_headers(user.id),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_get_story_history_returns_list_with_events(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+    db_session: AsyncSession,
+) -> None:
+    """After creating an edit event, the history endpoint returns it."""
+    # Insert an edit event directly so we don't need to call OpenAI
+    event = EditEvent.create_edit_event(
+        project_id=project.id,
+        target_type=EditEventTargetType.STORY,
+        target_id=story.id,
+        operation_type=EditEventOperationType.GENERATE_STORY,
+        user_instruction="write me a story",
+        status=EditEventStatus.SUCCEEDED,
+        output_snapshot={"storyText": "Once upon a time…"},
+    )
+    db_session.add(event)
+    await db_session.commit()
+
+    response = await api_client.get(
+        _history_url(project.id, story.id),
+        headers=_auth_headers(user.id),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body, list)
+    assert len(body) >= 1
+
+    found = next((e for e in body if e["targetId"] == str(story.id)), None)
+    assert found is not None
+
+
+async def test_get_story_history_event_shape(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+    db_session: AsyncSession,
+) -> None:
+    """Each history entry has all EditEventResponseSchema fields.
+
+    Adding or removing schema fields should surface here.
+    """
+    event = EditEvent.create_edit_event(
+        project_id=project.id,
+        target_type=EditEventTargetType.STORY,
+        target_id=story.id,
+        operation_type=EditEventOperationType.GENERATE_STORY,
+        user_instruction="make a comic story",
+        status=EditEventStatus.SUCCEEDED,
+    )
+    db_session.add(event)
+    await db_session.commit()
+
+    response = await api_client.get(
+        _history_url(project.id, story.id),
+        headers=_auth_headers(user.id),
+    )
+
+    assert response.status_code == 200
+    entry = response.json()[0]
+
+    # Fields from EditEventResponseSchema
+    assert "id" in entry
+    assert "projectId" in entry
+    assert "targetType" in entry
+    assert "targetId" in entry
+    assert "operationType" in entry
+    assert "userInstruction" in entry
+    assert "status" in entry
+    assert "createdAt" in entry
+    # outputSnapshot may be null — but the key must be present
+    assert "outputSnapshot" in entry
+
+
+async def test_get_story_history_requires_auth(
+    api_client: AsyncClient,
+    project: Project,
+    story: Story,
+) -> None:
+    """GET story history without a token returns 401."""
+    response = await api_client.get(_history_url(project.id, story.id))
+    assert response.status_code == 401
+
+
+async def test_get_story_history_limit_param(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+    db_session: AsyncSession,
+) -> None:
+    """The `limit` query param caps how many events are returned."""
+    # Create 5 events
+    for i in range(5):
+        event = EditEvent.create_edit_event(
+            project_id=project.id,
+            target_type=EditEventTargetType.STORY,
+            target_id=story.id,
+            operation_type=EditEventOperationType.GENERATE_STORY,
+            user_instruction=f"instruction {i}",
+            status=EditEventStatus.SUCCEEDED,
+        )
+        db_session.add(event)
+    await db_session.commit()
+
+    response = await api_client.get(
+        _history_url(project.id, story.id),
+        headers=_auth_headers(user.id),
+        params={"limit": 2},
+    )
+
+    assert response.status_code == 200
+    assert len(response.json()) <= 2

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -1,0 +1,465 @@
+"""
+API tests for authentication endpoints.
+
+POST /api/auth/signup
+POST /api/auth/signin
+POST /api/auth/logout
+POST /api/auth/refresh
+GET  /api/auth/me
+
+Tests focus on observable side effects and invariants:
+- Correct response shapes (field names, types)
+- State changes in the DB (session rows created/revoked)
+- Cookie mechanics (set on login, cleared on logout)
+- Auth boundary enforcement (401 when token missing or invalid)
+
+No mocking. Real FastAPI app, real Postgres.
+Fixtures in conftest.py handle user creation and cleanup.
+"""
+
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.auth.managers.jwt import JWTTokenManager
+from core.auth.models.user import User
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_jwt = JWTTokenManager()
+
+
+def _auth_headers(user_id: uuid.UUID) -> dict[str, str]:
+    """Produce a valid Bearer token for the given user ID."""
+    token = _jwt.create_access_token(user_id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _unique_email() -> str:
+    return f"test-{uuid.uuid4()}@example.com"
+
+
+# ---------------------------------------------------------------------------
+# POST /api/auth/signup
+# ---------------------------------------------------------------------------
+
+
+async def test_signup_creates_user_and_returns_token(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Signing up returns an access token and the new user's email."""
+    email = _unique_email()
+    response = await api_client.post(
+        "/api/auth/signup",
+        json={"email": email, "password": "correct-horse-battery"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+
+    assert body["user"]["email"] == email
+    assert isinstance(body["accessToken"], str)
+    assert len(body["accessToken"]) > 0
+
+    # Teardown: remove the user created by this test
+    await db_session.execute(
+        text('DELETE FROM "user" WHERE email = :email'), {"email": email}
+    )
+    await db_session.commit()
+
+
+async def test_signup_sets_refresh_token_cookie(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Signup sets an HttpOnly refresh_token cookie."""
+    email = _unique_email()
+    response = await api_client.post(
+        "/api/auth/signup",
+        json={"email": email, "password": "correct-horse-battery"},
+    )
+
+    assert response.status_code == 200
+    assert "refresh_token" in response.cookies
+
+    await db_session.execute(
+        text('DELETE FROM "user" WHERE email = :email'), {"email": email}
+    )
+    await db_session.commit()
+
+
+async def test_signup_duplicate_email_returns_400(
+    api_client: AsyncClient,
+    user: User,
+) -> None:
+    """Registering with an already-used email returns 400."""
+    response = await api_client.post(
+        "/api/auth/signup",
+        json={"email": user.email, "password": "doesnt-matter"},
+    )
+
+    assert response.status_code == 400
+
+
+async def test_signup_response_shape(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The signup response has exactly the fields the API contract specifies.
+
+    Changing UserResponse (e.g. adding/removing fields) should surface here.
+    """
+    email = _unique_email()
+    response = await api_client.post(
+        "/api/auth/signup",
+        json={"email": email, "password": "shape-test-password"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+
+    user_obj = body["user"]
+    assert "id" in user_obj
+    assert "email" in user_obj
+    assert "updatedAt" in user_obj
+    # password_hash must never leak
+    assert "passwordHash" not in user_obj
+    assert "password" not in user_obj
+
+    await db_session.execute(
+        text('DELETE FROM "user" WHERE email = :email'), {"email": email}
+    )
+    await db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/auth/signin
+# ---------------------------------------------------------------------------
+
+
+async def test_signin_returns_token(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Signing in with valid credentials returns an access token."""
+    email = _unique_email()
+    password = "test-password-123"
+
+    # Register first
+    signup_resp = await api_client.post(
+        "/api/auth/signup", json={"email": email, "password": password}
+    )
+    assert signup_resp.status_code == 200
+
+    # Sign in
+    response = await api_client.post(
+        "/api/auth/signin", json={"email": email, "password": password}
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body["accessToken"], str)
+    assert body["user"]["email"] == email
+
+    await db_session.execute(
+        text('DELETE FROM "user" WHERE email = :email'), {"email": email}
+    )
+    await db_session.commit()
+
+
+async def test_signin_wrong_password_returns_401(
+    api_client: AsyncClient,
+    user: User,
+) -> None:
+    """Wrong password on a real user returns 401."""
+    response = await api_client.post(
+        "/api/auth/signin",
+        json={"email": user.email, "password": "definitely-wrong"},
+    )
+
+    assert response.status_code == 401
+
+
+async def test_signin_unknown_email_returns_401(
+    api_client: AsyncClient,
+) -> None:
+    """Attempting to sign in with a valid-format but non-existent email returns 401.
+
+    This exercises the auth logic path (user lookup fails → 401).
+    Distinct from the Pydantic validation path tested below.
+    """
+    response = await api_client.post(
+        "/api/auth/signin",
+        json={"email": "nobody@example.com", "password": "irrelevant"},
+    )
+
+    assert response.status_code == 401
+
+
+async def test_signin_invalid_email_format_returns_422(
+    api_client: AsyncClient,
+) -> None:
+    """A syntactically invalid email is rejected by Pydantic before auth runs → 422.
+
+    This documents that input validation fires at the request-parsing layer,
+    not at the auth/DB layer.  The two error paths are distinct invariants.
+    """
+    response = await api_client.post(
+        "/api/auth/signin",
+        json={"email": "not-an-email", "password": "irrelevant"},
+    )
+
+    assert response.status_code == 422
+
+
+async def test_signin_creates_session_row(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A successful signin persists a session row in the DB."""
+    email = _unique_email()
+    password = "session-row-test"
+
+    await api_client.post(
+        "/api/auth/signup", json={"email": email, "password": password}
+    )
+    await api_client.post(
+        "/api/auth/signin", json={"email": email, "password": password}
+    )
+
+    # Confirm at least one un-revoked session exists for this user
+    result = await db_session.execute(
+        text(
+            'SELECT s.id FROM session s JOIN "user" u ON s.user_id = u.id '
+            "WHERE u.email = :email AND s.revoked_at IS NULL"
+        ),
+        {"email": email},
+    )
+    rows = result.fetchall()
+    assert len(rows) >= 1
+
+    await db_session.execute(
+        text('DELETE FROM "user" WHERE email = :email'), {"email": email}
+    )
+    await db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/auth/logout
+# ---------------------------------------------------------------------------
+
+
+async def test_logout_revokes_session(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Logging out marks the session as revoked in the DB."""
+    email = _unique_email()
+    password = "logout-test-pw"
+
+    # Signup to get a session cookie
+    signup_resp = await api_client.post(
+        "/api/auth/signup", json={"email": email, "password": password}
+    )
+    assert signup_resp.status_code == 200
+    refresh_token = signup_resp.cookies.get("refresh_token")
+    assert refresh_token
+
+    # Logout using the cookie
+    logout_resp = await api_client.post(
+        "/api/auth/logout",
+        cookies={"refresh_token": refresh_token},
+    )
+    assert logout_resp.status_code == 200
+    assert logout_resp.json()["message"] == "LOGGED_OUT"
+
+    # The session must now be revoked in the DB
+    result = await db_session.execute(
+        text(
+            'SELECT s.revoked_at FROM session s JOIN "user" u ON s.user_id = u.id '
+            "WHERE u.email = :email ORDER BY s.created_at DESC LIMIT 1"
+        ),
+        {"email": email},
+    )
+    row = result.fetchone()
+    assert row is not None
+    assert row[0] is not None  # revoked_at is set
+
+    await db_session.execute(
+        text('DELETE FROM "user" WHERE email = :email'), {"email": email}
+    )
+    await db_session.commit()
+
+
+async def test_logout_without_cookie_returns_401(
+    api_client: AsyncClient,
+) -> None:
+    """Logout without a refresh token cookie returns 401."""
+    response = await api_client.post("/api/auth/logout")
+    assert response.status_code == 401
+
+
+async def test_logout_clears_cookie(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The logout response deletes the refresh_token cookie."""
+    email = _unique_email()
+    signup_resp = await api_client.post(
+        "/api/auth/signup",
+        json={"email": email, "password": "cookie-clear-test"},
+    )
+    refresh_token = signup_resp.cookies.get("refresh_token")
+    assert refresh_token
+
+    logout_resp = await api_client.post(
+        "/api/auth/logout",
+        cookies={"refresh_token": refresh_token},
+    )
+    assert logout_resp.status_code == 200
+    # The cookie should be deleted (value empty or absent)
+    cookie_val = logout_resp.cookies.get("refresh_token")
+    assert not cookie_val  # empty string or absent
+
+    await db_session.execute(
+        text('DELETE FROM "user" WHERE email = :email'), {"email": email}
+    )
+    await db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/auth/refresh
+# ---------------------------------------------------------------------------
+
+
+async def test_refresh_returns_new_access_token(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A valid refresh token cookie yields a new access token."""
+    email = _unique_email()
+    signup_resp = await api_client.post(
+        "/api/auth/signup",
+        json={"email": email, "password": "refresh-test-pw"},
+    )
+    assert signup_resp.status_code == 200
+    refresh_token = signup_resp.cookies.get("refresh_token")
+    assert refresh_token
+
+    refresh_resp = await api_client.post(
+        "/api/auth/refresh",
+        cookies={"refresh_token": refresh_token},
+    )
+
+    assert refresh_resp.status_code == 200
+    body = refresh_resp.json()
+    assert isinstance(body["accessToken"], str)
+    assert len(body["accessToken"]) > 0
+
+    await db_session.execute(
+        text('DELETE FROM "user" WHERE email = :email'), {"email": email}
+    )
+    await db_session.commit()
+
+
+async def test_refresh_without_cookie_returns_401(
+    api_client: AsyncClient,
+) -> None:
+    """Calling /refresh with no cookie returns 401."""
+    response = await api_client.post("/api/auth/refresh")
+    assert response.status_code == 401
+
+
+async def test_refresh_after_logout_returns_401(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Using a revoked refresh token to refresh returns 401."""
+    email = _unique_email()
+    signup_resp = await api_client.post(
+        "/api/auth/signup",
+        json={"email": email, "password": "revoke-test-pw"},
+    )
+    refresh_token = signup_resp.cookies.get("refresh_token")
+    assert refresh_token
+
+    # Revoke it via logout
+    await api_client.post(
+        "/api/auth/logout",
+        cookies={"refresh_token": refresh_token},
+    )
+
+    # Try to refresh with the now-revoked token
+    response = await api_client.post(
+        "/api/auth/refresh",
+        cookies={"refresh_token": refresh_token},
+    )
+    assert response.status_code == 401
+
+    await db_session.execute(
+        text('DELETE FROM "user" WHERE email = :email'), {"email": email}
+    )
+    await db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/auth/me
+# ---------------------------------------------------------------------------
+
+
+async def test_me_returns_user(
+    api_client: AsyncClient,
+    user: User,
+) -> None:
+    """GET /me with a valid token returns the authenticated user's data."""
+    response = await api_client.get("/api/auth/me", headers=_auth_headers(user.id))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == str(user.id)
+    assert body["email"] == user.email
+
+
+async def test_me_without_token_returns_401(
+    api_client: AsyncClient,
+) -> None:
+    """GET /me without an auth header returns 401."""
+    response = await api_client.get("/api/auth/me")
+    assert response.status_code == 401
+
+
+async def test_me_with_malformed_token_returns_401(
+    api_client: AsyncClient,
+) -> None:
+    """GET /me with a garbage token returns 401."""
+    response = await api_client.get(
+        "/api/auth/me",
+        headers={"Authorization": "Bearer this.is.garbage"},
+    )
+    assert response.status_code == 401
+
+
+async def test_me_response_shape(
+    api_client: AsyncClient,
+    user: User,
+) -> None:
+    """The /me response has the exact fields in UserResponse.
+
+    If UserResponse gains or loses a field, this test should catch it.
+    """
+    response = await api_client.get("/api/auth/me", headers=_auth_headers(user.id))
+
+    assert response.status_code == 200
+    body = response.json()
+
+    assert "id" in body
+    assert "email" in body
+    assert "updatedAt" in body
+    # password must never be in the response
+    assert "password" not in body
+    assert "passwordHash" not in body


### PR DESCRIPTION
## Summary

- **72 new tests** covering all non-LLM endpoints in `api/v2`: auth, projects, stories, character list, and character history
- Tests assert on **DB side-effects and response shape invariants** — no mocks, real Postgres, in-process httpx transport
- Schema boundary tests: any field rename/removal in a Pydantic response schema will fail the corresponding shape test
- Auth boundary tested on every endpoint

## Bugs fixed (found by the tests)

| Bug | Fix |
|-----|-----|
| `DELETE /projects/{id}/story/{id}` returned 200 instead of 204 | Added `status_code=204` to the route decorator |
| `delete_story` raised the repo-layer `NotFoundError` which the route handler didn't catch (two different classes) → unhandled 500 | Service layer now translates `RepoNotFoundError` → `NotFoundError` |
| `GET /characters` had no auth guard → publicly accessible | Added `get_current_user_id` dependency |
| `GET /character/{id}/history` had no auth guard → publicly accessible | Added `get_current_user_id` dependency |

## Smoke test updates (`test_character_refine_smoke.py`)

- Added `Bearer` token to all three manual smoke test requests (required now that history endpoint is auth-guarded)
- Expanded `possible_operation_types` to include `upload_reference_image` (the DB now has events of that type for the hardcoded character)
- Scoped `userInstruction != ""` assertion to operations that actually carry a user instruction (uploads don't)

## Test files added

| File | Tests | Coverage |
|------|-------|----------|
| `tests/test_auth_api.py` | 19 | signup, signin (401 + 422 paths), logout, refresh, /me |
| `tests/story_engine/test_projects_api.py` | 25 | list/create/get project, create/delete story |
| `tests/story_engine/test_story_api.py` | 12 | get story, story history |
| `tests/story_engine/test_character_list_history_api.py` | 17 | character list, character history |