### PR TITLE
fix(ci): read PULUMI_BACKEND_URL from GitHub Actions variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,6 +131,7 @@ jobs:
         working-directory: infra
         env:
           PULUMI_CONFIG_PASSPHRASE: ""
+          PULUMI_BACKEND_URL: ${{ vars.PULUMI_BACKEND_URL }}
         run: |
           pulumi config set image_tag ${{ env.SHA }} --stack main
           pulumi up --stack main --yes
@@ -151,6 +152,7 @@ jobs:
         working-directory: infra
         env:
           PULUMI_CONFIG_PASSPHRASE: ""
+          PULUMI_BACKEND_URL: ${{ vars.PULUMI_BACKEND_URL }}
         run: |
           echo "SERVICE_URL=$(pulumi stack output service_url --stack main)" >> $GITHUB_ENV
 

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -84,6 +84,21 @@ setup:
 	@echo "Step 8 — Run initial database migrations:"
 	@echo "  make migrate    # triggers Cloud Run Job, no proxy needed"
 	@echo ""
+	@echo "Step 9 — Set GitHub Actions repository variables (one-time, per repo):"
+	@echo "  Go to: GitHub repo → Settings → Secrets and variables → Actions → Variables"
+	@echo "  Add the following variable (not secret — it is not sensitive):"
+	@echo ""
+	@echo "    PULUMI_BACKEND_URL = gs://storyengine-infra-state"
+	@echo ""
+	@echo "  Why: Pulumi defaults to Pulumi Cloud in non-interactive sessions."
+	@echo "  This variable tells the CI pipeline to use the GCS state backend instead."
+	@echo "  It cannot be read from Pulumi itself — it is the bootstrap value that"
+	@echo "  Pulumi needs before it can run any command."
+	@echo ""
+	@echo "  Also add the two Workload Identity secrets (from pulumi stack output):"
+	@echo "    GCP_WORKLOAD_IDENTITY_PROVIDER = \$$(pulumi stack output workload_identity_provider --stack main)"
+	@echo "    GCP_SERVICE_ACCOUNT            = \$$(pulumi stack output github_actions_sa_email --stack main)"
+	@echo ""
 
 # ── Pulumi ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

The deploy pipeline fails at `pulumi up` with:

```
error: PULUMI_ACCESS_TOKEN must be set for login during non-interactive CLI sessions
```

Pulumi defaults to Pulumi Cloud on a fresh runner with no login state. This stack uses a self-managed GCS backend.

## Fix

Add `PULUMI_BACKEND_URL: ${{ vars.PULUMI_BACKEND_URL }}` to the two Pulumi steps in `deploy.yml`. Also documents the required GitHub Actions variable in `make setup` (Step 9) alongside the existing WIF secrets.

## Required action before merging

Add the repository variable in GitHub:
**Settings → Secrets and variables → Actions → Variables → New repository variable**

| Name | Value |
|---|---|
| `PULUMI_BACKEND_URL` | `gs://storyengine-infra-state` |

Note: this is a **variable** (not a secret) — the bucket name is not sensitive.