### PR TITLE
feat(infra): api.dekatha.com routing, security hardening, and infra as a template

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,7 +154,7 @@ jobs:
           PULUMI_CONFIG_PASSPHRASE: ""
           PULUMI_BACKEND_URL: ${{ vars.PULUMI_BACKEND_URL }}
         run: |
-          echo "SERVICE_URL=$(pulumi stack output service_url --stack main)" >> $GITHUB_ENV
+          echo "SERVICE_URL=$(pulumi stack output api_url --stack main)" >> $GITHUB_ENV
 
       # Node.js is installed here (not at the top) so the earlier steps don't
       # carry unnecessary tooling. npm cache is keyed on the lockfile.
@@ -191,5 +191,5 @@ jobs:
           echo "| | |" >> $GITHUB_STEP_SUMMARY
           echo "|---|---|" >> $GITHUB_STEP_SUMMARY
           echo "| **Image tag** | \`${{ env.SHA }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Backend** | https://storyengine-main-backend-aojdjt3wia-nw.a.run.app |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Backend** | https://api.dekatha.com |" >> $GITHUB_STEP_SUMMARY
           echo "| **Frontend** | https://app.dekatha.com |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,15 +146,18 @@ jobs:
             --project shared-apps-infrastructure \
             --wait
 
-      # Read the live backend URL from Pulumi so the frontend build always
-      # bakes in the correct value — never a stale hardcoded URL.
-      - name: Get backend service URL
+      # Read all domain-derived values from the live stack so nothing is
+      # hardcoded in this file. A domain change in Pulumi.main.yaml is the
+      # single source of truth — no changes needed here.
+      - name: Get stack outputs
         working-directory: infra
         env:
           PULUMI_CONFIG_PASSPHRASE: ""
           PULUMI_BACKEND_URL: ${{ vars.PULUMI_BACKEND_URL }}
         run: |
           echo "SERVICE_URL=$(pulumi stack output api_url --stack main)" >> $GITHUB_ENV
+          echo "FRONTEND_BUCKET=$(pulumi stack output frontend_bucket --stack main)" >> $GITHUB_ENV
+          echo "FRONTEND_URL=$(pulumi stack output frontend_url --stack main)" >> $GITHUB_ENV
 
       # Node.js is installed here (not at the top) so the earlier steps don't
       # carry unnecessary tooling. npm cache is keyed on the lockfile.
@@ -178,7 +181,7 @@ jobs:
       # after a partial failure is safe.
       - name: Sync frontend to GCS
         run: |
-          gcloud storage rsync frontend/dist/ gs://app.dekatha.com \
+          gcloud storage rsync frontend/dist/ gs://${{ env.FRONTEND_BUCKET }} \
             --recursive \
             --delete-unmatched-destination-objects \
             --project shared-apps-infrastructure
@@ -191,5 +194,5 @@ jobs:
           echo "| | |" >> $GITHUB_STEP_SUMMARY
           echo "|---|---|" >> $GITHUB_STEP_SUMMARY
           echo "| **Image tag** | \`${{ env.SHA }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Backend** | https://api.dekatha.com |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Frontend** | https://app.dekatha.com |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Backend** | ${{ env.SERVICE_URL }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Frontend** | ${{ env.FRONTEND_URL }} |" >> $GITHUB_STEP_SUMMARY

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -28,6 +28,11 @@ class AppSettings(BaseSettings):
     # Cloud Run services authenticate via the attached service account (no key file).
     google_application_credentials: str = ""
 
+    # Deployment environment. Controls whether API docs are exposed.
+    # Set to "production" via plain env var in Cloud Run (cloudrun.py).
+    # Defaults to "development" locally — docs available at /docs.
+    env: str = "development"
+
     model_config = SettingsConfigDict(
         env_file=".env.local",
         env_ignore_empty=True,

--- a/backend/main.py
+++ b/backend/main.py
@@ -26,7 +26,17 @@ async def lifecycle_manager(app: FastAPI) -> AsyncGenerator[None, None]:
     logger.info("StoryEngine shutting down")
 
 
-fastapi_app = FastAPI(lifespan=lifecycle_manager)
+_is_production = settings.env == "production"
+
+fastapi_app = FastAPI(
+    lifespan=lifecycle_manager,
+    # Disable API docs in production — avoids exposing endpoint schema
+    # and request/response shapes to the public internet.
+    # Locally (env=development) docs remain available at /docs and /redoc.
+    docs_url=None if _is_production else "/docs",
+    redoc_url=None if _is_production else "/redoc",
+    openapi_url=None if _is_production else "/openapi.json",
+)
 
 # CORS_ORIGINS is a comma-separated list of allowed origins.
 # Defaults to localhost:5173 for local dev — no .env.local change needed.

--- a/infra/AGENT.md
+++ b/infra/AGENT.md
@@ -1,0 +1,385 @@
+# Infra Agent Reference
+
+Quick reference for AI agents working in this directory. Read this before
+touching anything. For the full reasoning behind decisions, see `DECISIONS.md`.
+
+---
+
+## What this is
+
+Pulumi Python project that provisions the full GCP stack for StoryEngine.
+One active stack: `main` → `app.dekatha.com`.
+
+Runtime: Python 3.12, toolchain: `uv`. Run everything from `infra/`.
+
+---
+
+## File map
+
+```
+__main__.py              Wiring — imports and calls all components in order
+Pulumi.yaml              Project definition (name, runtime, toolchain)
+Pulumi.main.yaml         Stack config (project, region, image_tag, domain)
+Makefile                 All operational commands — run `make help`
+DECISIONS.md             Full reasoning for non-obvious choices
+components/
+  config.py              Single source of truth: PROJECT, REGION, PREFIX, IMAGE_TAG, DOMAIN
+  storage.py             Layer 1 — GCS media bucket (private, signed URLs)
+  iam.py                 Layers 2+5 — localhost-sa, cloudrun-sa, all IAM bindings
+  registry.py            Layer 3 — Artifact Registry Docker repo
+  secrets.py             Layer 4 — Secret Manager containers (slots only, not values)
+  networking.py          Layer 6 — VPC, subnet, private services peering
+  database.py            Layer 7 — Cloud SQL Postgres 16, private IP, random password
+  cloudrun.py            Layer 8 — Cloud Run service (backend)
+  migrations.py          Layer 9 — Cloud Run Job (alembic upgrade head)
+  frontend.py            Layer 8 — GCS bucket + Global LB + SSL cert + HTTP redirect
+  ci.py                  Layer 10 — github-actions-sa + Workload Identity Federation
+scripts/
+  populate-secrets.sh    Push .env.local secrets to Secret Manager (idempotent)
+keys/
+  *.json                 SA key files — gitignored, never commit
+```
+
+---
+
+## Layer order in `__main__.py`
+
+Order matters — later layers depend on earlier ones. Pass dependencies
+explicitly so Pulumi sequences operations correctly.
+
+```
+1   storage       GCS media bucket
+2   iam           localhost-sa (needs bucket)
+3   registry      Artifact Registry repo
+4   secrets       Secret Manager containers
+5   iam           cloudrun-sa (needs bucket, registry, secrets)
+6   networking    VPC + subnet + peering
+7   database      Cloud SQL (needs VPC + peering + secrets)
+    __main__      Write DATABASE_URL SecretVersion (needs db output)
+8   cloudrun      Cloud Run service (needs SA, secrets, registry_url, vpc, subnet)
+9   migrations    Cloud Run Job (needs SA, secrets, registry_url, vpc, subnet)
+8   frontend      GCS + LB + SSL (no dependencies)
+10  ci            github-actions-sa + WIF (needs registry, cloudrun_sa, frontend.bucket)
+```
+
+---
+
+## Naming conventions
+
+All resource names use `PREFIX = f"storyengine-{stack}"` — currently `storyengine-main`.
+
+```python
+from components.config import PREFIX, resource_name
+
+resource_name("backend")   # → "storyengine-main-backend"
+resource_name("migrate")   # → "storyengine-main-migrate"
+f"{PREFIX}-some-secret"    # → "storyengine-main-some-secret"
+```
+
+Use `resource_name()` for GCP resource names. Use `f"{PREFIX}-..."` for
+Secret Manager secret IDs and bucket names. Never hardcode `storyengine-main`.
+
+**Image tags:** always git SHA, never `latest`. The SHA is stamped into
+`Pulumi.main.yaml` via `pulumi config set image_tag <sha>` before every deploy.
+
+---
+
+## How to add a new secret (e.g. Stripe API key)
+
+### Step 1 — `components/secrets.py`
+
+Add a new secret container to `AppSecrets.__init__`:
+
+```python
+self.stripe_api_key = _make_secret(
+    "secret-stripe-api-key",
+    f"{PREFIX}-stripe-api-key",
+)
+```
+
+### Step 2 — `components/iam.py` → `create_cloudrun_sa()`
+
+Grant `cloudrun-sa` access to read the new secret:
+
+```python
+gcp.secretmanager.SecretIamMember(
+    "cloudrun-sa-stripe-accessor",
+    secret_id=secrets.stripe_api_key.secret_id,
+    role="roles/secretmanager.secretAccessor",
+    member=member,
+)
+```
+
+### Step 3 — `components/cloudrun.py` → `create_cloudrun_service()`
+
+Add to `secret_env_vars`:
+
+```python
+gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(
+    name="STRIPE_API_KEY",
+    value_source=gcp.cloudrunv2.ServiceTemplateContainerEnvValueSourceArgs(
+        secret_key_ref=gcp.cloudrunv2.ServiceTemplateContainerEnvValueSourceSecretKeyRefArgs(
+            secret=secrets.stripe_api_key.secret_id,
+            version="latest",
+        ),
+    ),
+),
+```
+
+Also pass `secrets.stripe_api_key` through the function signature if needed.
+
+### Step 4 — Apply infra
+
+```bash
+make up   # provisions the Secret Manager container + IAM binding + Cloud Run wiring
+```
+
+### Step 5 — Push the value
+
+Add to `backend/.env.local` under `# --- secrets ---`:
+
+```
+STRIPE_API_KEY=sk_live_...
+```
+
+Then:
+
+```bash
+make populate-secrets
+```
+
+### Step 6 — Redeploy to pick up the new secret
+
+```bash
+make deploy-backend   # new Cloud Run revision fetches the secret at startup
+```
+
+---
+
+## How to add a plain env var (non-secret)
+
+For values that aren't sensitive (project IDs, bucket names, feature flags),
+skip Secret Manager entirely. Add directly to `plain_env_vars` in
+`components/cloudrun.py`:
+
+```python
+"SOME_CONFIG_VALUE": "the-value",
+```
+
+Then `make up` — no `populate-secrets`, no IAM changes needed.
+
+---
+
+## How the DB password is generated and wired
+
+This is the pattern for any credential that must be auto-generated:
+
+```python
+# components/database.py
+password = random.RandomPassword("db-password", length=32, special=False)
+
+# Store raw password in Secret Manager (retrievable for debugging)
+gcp.secretmanager.SecretVersion(
+    "db-password-version",
+    secret=secrets.db_password.id,
+    secret_data=password.result,
+)
+
+# Construct DATABASE_URL from the private IP + generated password
+# and write it as a SecretVersion — Cloud Run reads this at startup
+database_url = pulumi.Output.concat(
+    "postgresql+psycopg://postgres:",
+    password.result,
+    "@", instance.private_ip_address,
+    "/postgres"
+)
+```
+
+Then in `__main__.py`, after the database is created:
+
+```python
+gcp.secretmanager.SecretVersion(
+    "database-url-version",
+    secret=secrets.database_url.id,
+    secret_data=db.database_url,
+)
+```
+
+Key point: `DATABASE_URL` is owned by Pulumi. It is constructed from the
+live Cloud SQL IP and generated password. It must never be manually managed.
+See `.env.local` structure below.
+
+---
+
+## `backend/.env.local` structure
+
+`populate-secrets.sh` reads this file and only uploads keys in the
+`# --- secrets ---` section. Everything under `# --- variables ---` is
+ignored by the script.
+
+```bash
+# --- secrets ---
+ANTHROPIC_API_KEY=...      ← uploaded to Secret Manager
+OPENAI_API_KEY=...         ← uploaded to Secret Manager
+FAL_API_KEY=...            ← uploaded to Secret Manager
+# DATABASE_URL goes here if you add it — but DON'T. See below.
+
+# --- variables ---
+DATABASE_URL=postgresql+psycopg://postgres:123456@localhost:5432/mydb  ← local only, NOT uploaded
+GCP_PROJECT_ID=shared-apps-infrastructure
+GCP_REGION=europe-west2
+GCP_STORAGE_BUCKET=storyengine-main-media-x7k2
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/infra/keys/main-localhost-sa-key.json
+```
+
+**Critical:** `DATABASE_URL` must always stay in `# --- variables ---`.
+If it ends up in `# --- secrets ---`, `make populate-secrets` will overwrite
+the Cloud SQL URL (written by Pulumi) with the local Postgres URL — Cloud Run
+silently breaks on the next cold start.
+
+---
+
+## How to add a new GCP resource (e.g. Redis / Memorystore)
+
+Pattern: one file per layer, one `create_*()` function, wire in `__main__.py`.
+
+1. **Create `components/redis.py`**
+
+```python
+import pulumi_gcp as gcp
+from components.config import PROJECT, REGION, resource_name
+
+def create_redis(vpc: gcp.compute.Network):
+    instance = gcp.redis.Instance(
+        "redis",
+        name=resource_name("redis"),
+        tier="BASIC",
+        memory_size_gb=1,
+        region=REGION,
+        authorized_network=vpc.id,
+    )
+    return instance
+```
+
+2. **Wire in `__main__.py`** — after networking (Layer 6), before Cloud Run (Layer 8):
+
+```python
+from components.redis import create_redis
+redis = create_redis(vpc)
+```
+
+3. **Pass the Redis host to Cloud Run** via `plain_env_vars` in `cloudrun.py`:
+
+```python
+"REDIS_HOST": redis.host,   # Pulumi Output[str] — resolved at deploy time
+```
+
+4. **Export the output** if useful:
+
+```python
+pulumi.export("redis_host", redis.host)
+```
+
+Any resource that needs VPC access follows the same pattern as Cloud SQL:
+it must be provisioned after the VPC peering connection is established.
+Pass `peering_connection` in `depends_on` if Pulumi can't infer the dependency.
+
+---
+
+## Reading live values from the stack
+
+Never hardcode URLs, bucket names, or IPs that come from Pulumi outputs.
+Read them at runtime:
+
+```bash
+# From the terminal
+pulumi stack output service_url --stack main
+pulumi stack output frontend_bucket --stack main
+pulumi stack output db_private_ip --stack main
+
+# Full list
+make outputs
+```
+
+In Python code outside Pulumi (e.g. scripts), use:
+
+```bash
+PULUMI_CONFIG_PASSPHRASE="" pulumi stack output service_url --stack main
+```
+
+In the CI pipeline, `VITE_BACKEND_URL` is injected from `pulumi stack output
+service_url` at frontend build time — never from `.env.production`.
+
+---
+
+## Key decisions — the ones you'll get wrong without this
+
+**`VITE_BACKEND_URL` is not in `.env.production`**
+Deliberately omitted. It is injected at build time from `pulumi stack output
+service_url`. Hardcoding it produces stale URLs when the stack is rebuilt.
+
+**`.venv/bin/uvicorn`, not `uv run uvicorn` in Dockerfile**
+`uv run` checks venv freshness at every startup and re-syncs if stale —
+inside a container this triggers a full package download, causing OOM and
+slow cold starts. The venv is built correctly at image build time. Call
+uvicorn directly from the venv.
+
+**`PULUMI_BACKEND_URL` is a GitHub Actions variable, not a secret**
+Value: `gs://my-app-pulumi-state`. Must be set as a repository *variable*
+(not secret) under Settings → Secrets and variables → Actions → Variables.
+Pulumi defaults to Pulumi Cloud in non-interactive sessions — this env var
+overrides that. It cannot be read from Pulumi itself (chicken-and-egg).
+
+**`my-app-pulumi-state` bucket is not managed by Pulumi**
+It predates the stack — it's where the stack state is stored. Never add it
+to `__main__.py` or any component. Pulumi cannot manage the bucket that
+stores its own state.
+
+**`roles/editor` for `github-actions-sa` is intentional**
+Pulumi manages 10+ resource types across the project. Enumerating individual
+roles is high-maintenance and breaks whenever a new resource type is added.
+`roles/editor` excludes IAM permissions — the SA cannot escalate its own
+privileges.
+
+**Cloud Run Job for migrations, not Auth Proxy**
+GitHub Actions runners are outside the VPC. Cloud SQL has a private IP only.
+The migration job runs inside the VPC via direct VPC egress. CI triggers it
+with `gcloud run jobs execute ... --wait` and reads the exit code.
+
+**`max_retries=0` on the migration job**
+A failed migration leaves the schema in a partially-applied state. Automatic
+retries make this worse. Fail fast, alert a human.
+
+---
+
+## What NOT to touch
+
+| Thing | Why |
+|---|---|
+| `my-app-pulumi-state` GCS bucket | Predates Pulumi, stores stack state — never manage via Pulumi |
+| `DATABASE_URL` in `.env.local` | Must stay in `# --- variables ---`, never `# --- secrets ---` |
+| `.github/workflows/ci.yml` trigger | PR-only by design — `deploy.yml` owns `main` |
+| `Pulumi.main.yaml` `image_tag` | Set automatically by `make deploy-backend` and CI — don't edit manually |
+
+---
+
+## Operational quick reference
+
+```bash
+make help              # full list of targets
+
+make preview           # dry run — what would pulumi up change?
+make up                # apply infra changes only (no image rebuild)
+make outputs           # print all stack outputs
+
+make deploy-backend    # build image → push → pulumi up
+make deploy-frontend   # build frontend (injects service_url) → rsync to GCS
+make deploy-all        # both, backend first
+
+make migrate           # trigger Cloud Run migration job, wait for exit code
+make populate-secrets  # push .env.local secrets to Secret Manager
+make rotate-secrets    # populate-secrets + deploy-backend (picks up new values)
+
+make status            # Cloud Run revision, SSL cert state, DNS, stack outputs
+make proxy             # Cloud SQL Auth Proxy on localhost:5433 (inspection only)
+```

--- a/infra/AGENT.md
+++ b/infra/AGENT.md
@@ -32,7 +32,7 @@ components/
   database.py            Layer 7 — Cloud SQL Postgres 16, private IP, random password
   cloudrun.py            Layer 8 — Cloud Run service (backend)
   migrations.py          Layer 9 — Cloud Run Job (alembic upgrade head)
-  frontend.py            Layer 8 — GCS bucket + Global LB + SSL cert + HTTP redirect
+  frontend.py            Layer 8 — GCS bucket + Global LB (shared frontend+API) + SSL cert + HTTP redirect
   ci.py                  Layer 10 — github-actions-sa + Workload Identity Federation
 scripts/
   populate-secrets.sh    Push .env.local secrets to Secret Manager (idempotent)
@@ -56,9 +56,9 @@ explicitly so Pulumi sequences operations correctly.
 6   networking    VPC + subnet + peering
 7   database      Cloud SQL (needs VPC + peering + secrets)
     __main__      Write DATABASE_URL SecretVersion (needs db output)
-8   cloudrun      Cloud Run service (needs SA, secrets, registry_url, vpc, subnet)
+8a  cloudrun      Cloud Run service (needs SA, secrets, registry_url, vpc, subnet)
 9   migrations    Cloud Run Job (needs SA, secrets, registry_url, vpc, subnet)
-8   frontend      GCS + LB + SSL (no dependencies)
+8b  frontend      GCS + shared LB + SSL (needs service for Serverless NEG)
 10  ci            github-actions-sa + WIF (needs registry, cloudrun_sa, frontend.bucket)
 ```
 
@@ -308,7 +308,7 @@ PULUMI_CONFIG_PASSPHRASE="" pulumi stack output service_url --stack main
 ```
 
 In the CI pipeline, `VITE_BACKEND_URL` is injected from `pulumi stack output
-service_url` at frontend build time — never from `.env.production`.
+api_url` at frontend build time — never from `.env.production`.
 
 ---
 
@@ -316,7 +316,7 @@ service_url` at frontend build time — never from `.env.production`.
 
 **`VITE_BACKEND_URL` is not in `.env.production`**
 Deliberately omitted. It is injected at build time from `pulumi stack output
-service_url`. Hardcoding it produces stale URLs when the stack is rebuilt.
+api_url`. Hardcoding it produces stale URLs when the stack is rebuilt.
 
 **`.venv/bin/uvicorn`, not `uv run uvicorn` in Dockerfile**
 `uv run` checks venv freshness at every startup and re-syncs if stale —
@@ -340,6 +340,14 @@ Pulumi manages 10+ resource types across the project. Enumerating individual
 roles is high-maintenance and breaks whenever a new resource type is added.
 `roles/editor` excludes IAM permissions — the SA cannot escalate its own
 privileges.
+
+**Frontend and API share one load balancer (cost decision)**
+`app.dekatha.com` (GCS) and `api.dekatha.com` (Cloud Run) share one Global IP,
+one SSL cert, and one set of forwarding rules via URL map host-based routing.
+A dedicated API LB costs ~$36/month extra (two additional forwarding rules).
+To decouple: extract the NEG + BackendService + new GlobalAddress + new SSL cert
++ new URLMap + new forwarding rules into `components/backend_lb.py`, remove the
+api host_rule and path_matcher from `frontend.py`, update DNS with a new A record.
 
 **Cloud Run Job for migrations, not Auth Proxy**
 GitHub Actions runners are outside the VPC. Cloud SQL has a private IP only.

--- a/infra/AGENT.md
+++ b/infra/AGENT.md
@@ -390,15 +390,17 @@ config:
   yourapp-infra:image_tag: latest   # updated automatically by make deploy-backend
 ```
 
-### Step 3 — Update the Makefile (one line)
+### Step 3 — No Makefile changes needed
+
+The Makefile reads the Pulumi project name directly from `Pulumi.yaml`:
 
 ```makefile
-APP := $(shell pulumi config get storyengine-infra:app ...)
-#                               ↑ change to yourapp-infra:app
+PULUMI_PROJECT := $(shell grep "^name:" Pulumi.yaml | awk '{print $$2}')
+APP            := $(shell pulumi config get $(PULUMI_PROJECT):app ...)
 ```
 
-That's it. All GCP resource names, the Makefile `PREFIX`, and the SSL cert
-filter all derive from `APP`. No other changes needed in the Makefile.
+Changing `name:` in `Pulumi.yaml` automatically updates the config key
+namespace used everywhere in the Makefile. No manual Makefile edits needed.
 
 ### Step 4 — Create a new GCS state bucket
 

--- a/infra/AGENT.md
+++ b/infra/AGENT.md
@@ -360,6 +360,66 @@ retries make this worse. Fail fast, alert a human.
 
 ---
 
+## Using this as a template for a new project
+
+This infra directory is designed to be reusable. To bootstrap a new project:
+
+### Step 1 — Rename the Pulumi project
+
+In `Pulumi.yaml`, change:
+```yaml
+name: storyengine-infra          # → yourapp-infra
+description: A story generator...  # → your description
+config:
+  storyengine-infra:app: storyengine  # → yourapp-infra:app: yourapp
+```
+
+The `name:` field drives the config key namespace (`storyengine-infra:` becomes
+`yourapp-infra:`). Every `storyengine-infra:` config key in `Pulumi.main.yaml`
+must be updated to match.
+
+### Step 2 — Update `Pulumi.main.yaml`
+
+```yaml
+config:
+  gcp:project: your-gcp-project
+  gcp:region: your-region
+  yourapp-infra:app: yourapp        # ← drives all GCP resource names
+  yourapp-infra:domain: app.yourdomain.com
+  yourapp-infra:api_domain: api.yourdomain.com
+  yourapp-infra:image_tag: latest   # updated automatically by make deploy-backend
+```
+
+### Step 3 — Update the Makefile (one line)
+
+```makefile
+APP := $(shell pulumi config get storyengine-infra:app ...)
+#                               ↑ change to yourapp-infra:app
+```
+
+That's it. All GCP resource names, the Makefile `PREFIX`, and the SSL cert
+filter all derive from `APP`. No other changes needed in the Makefile.
+
+### Step 4 — Create a new GCS state bucket
+
+```bash
+gcloud storage buckets create gs://yourapp-pulumi-state \
+  --project your-gcp-project \
+  --location your-region
+```
+
+Set `PULUMI_BACKEND_URL=gs://yourapp-pulumi-state` in GitHub Actions variables.
+
+### Step 5 — Init the stack and deploy
+
+```bash
+pulumi stack init main
+make up       # provisions all GCP resources
+make setup    # prints remaining manual steps
+```
+
+---
+
 ## What NOT to touch
 
 | Thing | Why |

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -47,6 +47,7 @@ help:
 	@echo "    make destroy            Tear down all infrastructure for this stack"
 	@echo "    make status             Show cert, Cloud Run revision, and stack outputs"
 	@echo "    make outputs            Show all Pulumi stack outputs"
+	@echo "    make change-domain      Step-by-step instructions for switching domains"
 	@echo ""
 
 # ── Setup (one-time onboarding) ───────────────────────────────────────────────
@@ -98,6 +99,55 @@ setup:
 	@echo "  Also add the two Workload Identity secrets (from pulumi stack output):"
 	@echo "    GCP_WORKLOAD_IDENTITY_PROVIDER = \$$(pulumi stack output workload_identity_provider --stack main)"
 	@echo "    GCP_SERVICE_ACCOUNT            = \$$(pulumi stack output github_actions_sa_email --stack main)"
+	@echo ""
+
+# ── Domain change (checklist) ─────────────────────────────────────────────────
+
+# Prints the exact steps to switch the stack to a new domain.
+# Not a fully automated target — a DNS change at the registrar is required
+# in the middle, which cannot be scripted. Follow each step in order.
+.PHONY: change-domain
+change-domain:
+	@echo ""
+	@echo "=== Domain change checklist ==="
+	@echo ""
+	@echo "Current domains:"
+	@echo "  frontend : $$(PULUMI_CONFIG_PASSPHRASE="" pulumi config get storyengine-infra:domain --stack $(STACK) 2>/dev/null)"
+	@echo "  api      : $$(PULUMI_CONFIG_PASSPHRASE="" pulumi config get storyengine-infra:api_domain --stack $(STACK) 2>/dev/null)"
+	@echo ""
+	@echo "Step 1 — Update both domains in Pulumi.$(STACK).yaml:"
+	@echo "  storyengine-infra:domain: app.newdomain.com"
+	@echo "  storyengine-infra:api_domain: api.newdomain.com"
+	@echo ""
+	@echo "Step 2 — Apply infra:"
+	@echo "  make up"
+	@echo ""
+	@echo "  What this does:"
+	@echo "    - Recreates the GCS bucket (must match domain — old bucket deleted)"
+	@echo "    - Replaces the SSL cert to cover the new domains"
+	@echo "    - Updates CORS_ORIGINS on Cloud Run to the new frontend domain"
+	@echo "    - Updates URL map host rules"
+	@echo "  Expect brief HTTPS disruption while the new cert provisions."
+	@echo "  Frontend will be down until step 5 (bucket recreated but empty)."
+	@echo ""
+	@echo "Step 3 — Get the load balancer IP:"
+	@echo "  make outputs | grep frontend_ip"
+	@echo ""
+	@echo "Step 4 — Update DNS at your registrar (DNS-only mode, not proxied):"
+	@echo "  A  app.newdomain.com  →  <frontend_ip from step 3>"
+	@echo "  A  api.newdomain.com  →  <frontend_ip from step 3>"
+	@echo "  Remove old A records for the previous domain."
+	@echo ""
+	@echo "Step 5 — Redeploy frontend (syncs assets to new bucket, bakes new API URL):"
+	@echo "  make deploy-frontend"
+	@echo ""
+	@echo "Step 6 — Wait for SSL cert to provision (~10-30 min after DNS propagates):"
+	@echo "  make status"
+	@echo "  Watch managed.status → ACTIVE for both new domains."
+	@echo ""
+	@echo "Step 7 — Verify:"
+	@echo "  curl https://app.newdomain.com"
+	@echo "  curl https://api.newdomain.com/health"
 	@echo ""
 
 # ── Pulumi ────────────────────────────────────────────────────────────────────

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,12 +1,13 @@
 STACK           := main
 PROJECT         := $(shell pulumi config get gcp:project --stack $(STACK) 2>/dev/null)
 REGION          := $(shell pulumi config get gcp:region --stack $(STACK) 2>/dev/null)
+# PULUMI_PROJECT reads the project name directly from Pulumi.yaml.
+# This drives the config key namespace (e.g. storyengine-infra:app).
+# For a new project, changing name: in Pulumi.yaml is the only change needed here.
+PULUMI_PROJECT  := $(shell grep "^name:" Pulumi.yaml | awk '{print $$2}')
 # APP and PREFIX drive all GCP resource names — must match config.py.
-# APP is read from Pulumi config (storyengine-infra:app) so a new project
-# only needs to change it in Pulumi.yaml. The config key prefix
-# (storyengine-infra:) is the Pulumi project name — if you rename the
-# project, update this line too.
-APP             := $(shell pulumi config get storyengine-infra:app --stack $(STACK) 2>/dev/null)
+# Reads from Pulumi config using the project name as the namespace prefix.
+APP             := $(shell pulumi config get $(PULUMI_PROJECT):app --stack $(STACK) 2>/dev/null)
 PREFIX          := $(APP)-$(STACK)
 # REGISTRY reads from stack output — derived from PROJECT + APP + STACK in registry.py.
 # Never construct this manually; the stack output is the single source of truth.
@@ -122,12 +123,12 @@ change-domain:
 	@echo "=== Domain change checklist ==="
 	@echo ""
 	@echo "Current domains:"
-	@echo "  frontend : $$(PULUMI_CONFIG_PASSPHRASE="" pulumi config get storyengine-infra:domain --stack $(STACK) 2>/dev/null)"
-	@echo "  api      : $$(PULUMI_CONFIG_PASSPHRASE="" pulumi config get storyengine-infra:api_domain --stack $(STACK) 2>/dev/null)"
+	@echo "  frontend : $$(PULUMI_CONFIG_PASSPHRASE="" pulumi config get $(PULUMI_PROJECT):domain --stack $(STACK) 2>/dev/null)"
+	@echo "  api      : $$(PULUMI_CONFIG_PASSPHRASE="" pulumi config get $(PULUMI_PROJECT):api_domain --stack $(STACK) 2>/dev/null)"
 	@echo ""
 	@echo "Step 1 — Update both domains in Pulumi.$(STACK).yaml:"
-	@echo "  storyengine-infra:domain: app.newdomain.com"
-	@echo "  storyengine-infra:api_domain: api.newdomain.com"
+	@echo "  $(PULUMI_PROJECT):domain: app.newdomain.com"
+	@echo "  $(PULUMI_PROJECT):api_domain: api.newdomain.com"
 	@echo ""
 	@echo "Step 2 — Apply infra:"
 	@echo "  make up"

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -181,13 +181,13 @@ status:
 		--format="table(metadata.name, status.conditions[0].status)" 2>&1
 	@echo ""
 	@echo "=== SSL Certificate ==="
-	@gcloud compute ssl-certificates describe storyengine-$(STACK)-frontend-cert \
+	@gcloud compute ssl-certificates describe storyengine-$(STACK)-frontend-cert-v2 \
 		--global --project $(PROJECT) \
 		--format="table(name, managed.status, managed.domainStatus)" 2>&1
 	@echo ""
 	@echo "=== DNS resolution ==="
-	@dig $(STACK).dekatha.com A +short 2>&1
-	@echo "(should be 136.110.212.53)"
+	@FRONTEND_URL=$$(PULUMI_CONFIG_PASSPHRASE="" pulumi stack output frontend_url --stack $(STACK) 2>/dev/null | sed 's|https://||'); \
+		dig $$FRONTEND_URL A +short 2>&1
 	@echo ""
 	@echo "=== Stack outputs ==="
 	@PULUMI_CONFIG_PASSPHRASE="" pulumi stack output --stack $(STACK)

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,15 +1,25 @@
 STACK           := main
 PROJECT         := $(shell pulumi config get gcp:project --stack $(STACK) 2>/dev/null)
 REGION          := $(shell pulumi config get gcp:region --stack $(STACK) 2>/dev/null)
-REGISTRY        := $(REGION)-docker.pkg.dev/$(PROJECT)/storyengine-$(STACK)
+# APP and PREFIX drive all GCP resource names — must match config.py.
+# APP is read from Pulumi config (storyengine-infra:app) so a new project
+# only needs to change it in Pulumi.yaml. The config key prefix
+# (storyengine-infra:) is the Pulumi project name — if you rename the
+# project, update this line too.
+APP             := $(shell pulumi config get storyengine-infra:app --stack $(STACK) 2>/dev/null)
+PREFIX          := $(APP)-$(STACK)
+# REGISTRY reads from stack output — derived from PROJECT + APP + STACK in registry.py.
+# Never construct this manually; the stack output is the single source of truth.
+REGISTRY        := $(shell PULUMI_CONFIG_PASSPHRASE="" pulumi stack output registry_url --stack $(STACK) 2>/dev/null)
 IMAGE           := $(REGISTRY)/backend
 BACKEND_DIR     := $(shell git rev-parse --show-toplevel)/backend
 FRONTEND_DIR    := $(shell git rev-parse --show-toplevel)/frontend
 FRONTEND_BUCKET := $(shell PULUMI_CONFIG_PASSPHRASE="" pulumi stack output frontend_bucket --stack $(STACK) 2>/dev/null)
+FRONTEND_URL    := $(shell PULUMI_CONFIG_PASSPHRASE="" pulumi stack output frontend_url --stack $(STACK) 2>/dev/null)
 SERVICE_URL     := $(shell PULUMI_CONFIG_PASSPHRASE="" pulumi stack output api_url --stack $(STACK) 2>/dev/null)
 DB_INSTANCE     := $(shell PULUMI_CONFIG_PASSPHRASE="" pulumi stack output db_instance_name --stack $(STACK) 2>/dev/null)
 MIGRATION_JOB   := $(shell PULUMI_CONFIG_PASSPHRASE="" pulumi stack output migration_job_name --stack $(STACK) 2>/dev/null)
-SA_KEY          := $(shell git rev-parse --show-toplevel)/infra/keys/$(STACK)-storage-sa-key.json
+SA_KEY          := $(shell git rev-parse --show-toplevel)/infra/keys/$(STACK)-localhost-sa-key.json
 
 # Git SHA of HEAD — used as the Docker image tag so every deployed revision
 # is traceable to an exact commit. Never use 'latest' as a tag in production.
@@ -89,7 +99,7 @@ setup:
 	@echo "  Go to: GitHub repo → Settings → Secrets and variables → Actions → Variables"
 	@echo "  Add the following variable (not secret — it is not sensitive):"
 	@echo ""
-	@echo "    PULUMI_BACKEND_URL = gs://storyengine-infra-state"
+	@echo "    PULUMI_BACKEND_URL = gs://my-app-pulumi-state"
 	@echo ""
 	@echo "  Why: Pulumi defaults to Pulumi Cloud in non-interactive sessions."
 	@echo "  This variable tells the CI pipeline to use the GCS state backend instead."
@@ -195,16 +205,16 @@ destroy:
 	@echo "=== Destroying $(STACK) stack ==="
 	@echo ""
 	@echo "Step 1/4: Deleting Cloud Run service + job (releases VPC address reservation)..."
-	-gcloud run services delete storyengine-$(STACK)-backend \
+	-gcloud run services delete $(PREFIX)-backend \
 		--region $(REGION) --project $(PROJECT) --quiet 2>/dev/null
-	-gcloud run jobs delete storyengine-$(STACK)-migrate \
+	-gcloud run jobs delete $(PREFIX)-migrate \
 		--region $(REGION) --project $(PROJECT) --quiet 2>/dev/null
 	@echo ""
 	@echo "Step 2/4: Waiting 30s for GCP to release serverless VPC address..."
 	@sleep 30
 	@echo ""
 	@echo "Step 3/4: Deleting Cloud SQL instance (releases VPC peering reference)..."
-	-gcloud sql instances delete storyengine-$(STACK)-postgres \
+	-gcloud sql instances delete $(PREFIX)-postgres \
 		--project $(PROJECT) --quiet 2>/dev/null
 	@echo ""
 	@echo "Step 4/4: Waiting 30s for Cloud SQL deletion to propagate..."
@@ -221,7 +231,7 @@ destroy:
 status:
 	@echo ""
 	@echo "=== Cloud Run (backend) ==="
-	@gcloud run services describe storyengine-$(STACK)-backend \
+	@gcloud run services describe $(PREFIX)-backend \
 		--region $(REGION) --project $(PROJECT) \
 		--format="table(status.latestReadyRevisionName, status.url)" 2>&1
 	@echo ""
@@ -231,7 +241,8 @@ status:
 		--format="table(metadata.name, status.conditions[0].status)" 2>&1
 	@echo ""
 	@echo "=== SSL Certificate ==="
-	@gcloud compute ssl-certificates describe storyengine-$(STACK)-frontend-cert-v2 \
+	@gcloud compute ssl-certificates list \
+		--filter="name~$(PREFIX)-frontend" \
 		--global --project $(PROJECT) \
 		--format="table(name, managed.status, managed.domainStatus)" 2>&1
 	@echo ""
@@ -300,7 +311,7 @@ sync-frontend:
 deploy-frontend: build-frontend sync-frontend
 	@echo ""
 	@echo "Frontend deployed to gs://$(FRONTEND_BUCKET)"
-	@echo "Live at: https://$(FRONTEND_BUCKET)"
+	@echo "Live at: $(FRONTEND_URL)"
 
 # ── Deploy both ───────────────────────────────────────────────────────────────
 

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -6,7 +6,7 @@ IMAGE           := $(REGISTRY)/backend
 BACKEND_DIR     := $(shell git rev-parse --show-toplevel)/backend
 FRONTEND_DIR    := $(shell git rev-parse --show-toplevel)/frontend
 FRONTEND_BUCKET := $(shell PULUMI_CONFIG_PASSPHRASE="" pulumi stack output frontend_bucket --stack $(STACK) 2>/dev/null)
-SERVICE_URL     := $(shell PULUMI_CONFIG_PASSPHRASE="" pulumi stack output service_url --stack $(STACK) 2>/dev/null)
+SERVICE_URL     := $(shell PULUMI_CONFIG_PASSPHRASE="" pulumi stack output api_url --stack $(STACK) 2>/dev/null)
 DB_INSTANCE     := $(shell PULUMI_CONFIG_PASSPHRASE="" pulumi stack output db_instance_name --stack $(STACK) 2>/dev/null)
 MIGRATION_JOB   := $(shell PULUMI_CONFIG_PASSPHRASE="" pulumi stack output migration_job_name --stack $(STACK) 2>/dev/null)
 SA_KEY          := $(shell git rev-parse --show-toplevel)/infra/keys/$(STACK)-storage-sa-key.json

--- a/infra/Pulumi.main.yaml
+++ b/infra/Pulumi.main.yaml
@@ -4,3 +4,4 @@ config:
   gcp:region: europe-west2
   storyengine-infra:image_tag: 1236fcc
   storyengine-infra:domain: app.dekatha.com
+  storyengine-infra:api_domain: api.dekatha.com

--- a/infra/Pulumi.yaml
+++ b/infra/Pulumi.yaml
@@ -8,3 +8,9 @@ config:
   pulumi:tags:
     value:
       pulumi:template: python
+  # App name — used as the prefix for all GCP resource names.
+  # Override in Pulumi.<stack>.yaml for a new project.
+  # If you change this, also update:
+  #   1. name: in this file (Pulumi project name — drives config key namespace)
+  #   2. APP := in Makefile (reads storyengine-infra:app — key prefix must match project name)
+  storyengine-infra:app: storyengine

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -63,7 +63,9 @@ service, service_url = create_cloudrun_service(
 migration_job = create_migration_job(cloudrun_sa, secrets, registry_url, vpc, subnet)
 
 # --- Layer 8: Frontend hosting ---
-frontend = create_frontend()
+# service is passed so the LB can create a Serverless NEG pointing at the
+# Cloud Run service — routing api.dekatha.com through the same LB as the frontend.
+frontend = create_frontend(service)
 
 # --- Layer 10: CI/CD (Workload Identity + github-actions-sa) ---
 ci = create_ci_resources(registry, cloudrun_sa, frontend.bucket)
@@ -86,6 +88,7 @@ pulumi.export("db_private_ip", db.instance.private_ip_address)
 pulumi.export("frontend_bucket", frontend.bucket.name)
 pulumi.export("frontend_ip", frontend.ip_address)
 pulumi.export("frontend_url", frontend.url)
+pulumi.export("api_url", frontend.api_url)
 pulumi.export("migration_job_name", migration_job.name)
 pulumi.export("workload_identity_provider", ci.provider_name)
 pulumi.export("github_actions_sa_email", ci.sa_email)

--- a/infra/components/cloudrun.py
+++ b/infra/components/cloudrun.py
@@ -52,6 +52,9 @@ def create_cloudrun_service(
             # Read in main.py via os.getenv("CORS_ORIGINS").
             # Not a secret — knowing this domain grants no access to anything.
             "CORS_ORIGINS": f"https://{DOMAIN}",
+            # Disables FastAPI's /docs, /redoc, and /openapi.json in Cloud Run.
+            # Locally defaults to "development" (docs available) via config.py.
+            "ENV": "production",
         }.items()
     ]
 

--- a/infra/components/config.py
+++ b/infra/components/config.py
@@ -23,8 +23,12 @@ REGION = _gcp.require("region")  # e.g. "europe-west2"
 # ── Stack / naming ─────────────────────────────────────────────────────────────
 
 STACK = pulumi.get_stack()  # "dev", "staging", "prod" — active stack name
-APP = "storyengine"
-PREFIX = f"{APP}-{STACK}"  # "storyengine-dev"
+
+# App name — read from Pulumi config so new projects can set their own prefix.
+# Default defined in Pulumi.yaml: storyengine-infra:app: storyengine
+# All GCP resource names derive from this via PREFIX and resource_name().
+APP = _app.require("app")
+PREFIX = f"{APP}-{STACK}"  # "storyengine-main"
 
 # ── App-level config ───────────────────────────────────────────────────────────
 

--- a/infra/components/config.py
+++ b/infra/components/config.py
@@ -38,6 +38,11 @@ IMAGE_TAG = _app.require("image_tag")  # git SHA set by make deploy-backend
 # "app.dekatha.com", a future "dev" stack can serve "dev.dekatha.com".
 DOMAIN = _app.require("domain")
 
+# API subdomain — served via the same load balancer as the frontend.
+# Routes to the Cloud Run backend service via a Serverless NEG.
+# Decoupling into a separate LB is possible but costs ~$36/month extra.
+API_DOMAIN = _app.require("api_domain")
+
 # Media bucket name. The x7k2 suffix was generated on first creation to
 # avoid naming conflicts. It is intentionally static — GCS bucket names are
 # globally unique and immutable. Change this only if you intend to recreate

--- a/infra/components/frontend.py
+++ b/infra/components/frontend.py
@@ -1,7 +1,7 @@
 import pulumi
 import pulumi_gcp as gcp
 
-from components.config import DOMAIN, resource_name
+from components.config import API_DOMAIN, DOMAIN, REGION, resource_name
 
 # Bucket name must match the domain exactly — GCP requirement for
 # custom domain hosting via backend bucket + load balancer.
@@ -14,59 +14,62 @@ class FrontendOutputs:
         bucket: gcp.storage.Bucket,
         ip_address: pulumi.Output[str],
         url: str,
+        api_url: str,
     ) -> None:
         self.bucket = bucket
         self.ip_address = ip_address
         self.url = url
+        self.api_url = api_url
 
 
-def create_frontend() -> FrontendOutputs:
+def create_frontend(service: gcp.cloudrunv2.Service) -> FrontendOutputs:
     """
-    Creates the static frontend hosting infrastructure for the stack domain.
+    Creates the static frontend hosting infrastructure and API routing.
 
     Architecture:
-      browser → Global Load Balancer (SSL termination, static IP)
-             → Backend Bucket
-             → GCS Bucket (serves static files)
+      browser → single Global Load Balancer (one IP, one SSL cert)
+             ├─ host: DOMAIN     → Backend Bucket → GCS (static frontend)
+             └─ host: API_DOMAIN → Backend Service → Serverless NEG → Cloud Run
 
-    The load balancer is necessary for two reasons:
-      1. SSL termination — GCS cannot serve HTTPS on a custom domain alone.
-         Google-managed certificates are provisioned automatically and
-         auto-renewed at no cost.
-      2. Custom domain routing — maps the domain to the GCS bucket.
+    Both domains share one Global IP, one SSL cert, one set of forwarding
+    rules. This saves ~$36/month vs a dedicated API load balancer (which
+    requires two additional forwarding rules billed at ~$18/month each).
 
-    The bucket is publicly readable (allUsers → objectViewer) because every
-    browser needs to fetch index.html, JS, CSS directly. Unlike the media
-    bucket (private, signed URLs), there is no sensitive content here.
-
-    HTTP (port 80) is redirected to HTTPS. No plaintext traffic reaches
-    the bucket.
-
-    SPA routing: both main_page_suffix and not_found_page are set to
-    index.html. This means all paths (including deep links like
-    /projects/123) return index.html and React Router handles routing
-    client-side. Without not_found_page=index.html, deep links return 404.
-
-    CDN is disabled for now — the load balancer is CDN-capable but we
-    don't need the caching layer yet. Enable by setting enable_cdn=True
-    on the BackendBucket resource.
+    NOTE — decoupling the API LB:
+      If a separate API load balancer is needed (e.g. for independent
+      scaling, CDN config, or IAM restrictions on the Cloud Run URL),
+      extract the following into components/backend_lb.py:
+        - RegionNetworkEndpointGroup (neg)
+        - BackendService (backend_service)
+        - A new GlobalAddress, ManagedSslCertificate for API_DOMAIN only
+        - A new URLMap, TargetHttpsProxy, GlobalForwardingRule (443 + 80)
+      Then remove the api host_rule and path_matcher from this URL map,
+      remove API_DOMAIN from the SSL cert domains, and add a new DNS
+      A record for API_DOMAIN pointing at the new IP.
 
     Deletion order:
-      GCP enforces a strict outside-in deletion order for load balancer
-      resources. Pulumi infers some of these from output references but
-      not all — particularly the forwarding rules' dependency on proxies
-      is through a string self_link that Pulumi may not trace deep enough.
-      We declare the full chain explicitly with depends_on so that on
-      destroy/replace Pulumi serialises deletions correctly:
+      GCP enforces strict outside-in deletion for load balancer resources.
+      The full correct order is:
 
-        forwarding rules → proxies → url maps + ssl cert → backend bucket
+        forwarding rules (443 + 80)
+          → proxies (https + http)
+            → url maps + ssl cert
+              → backend bucket + backend service
+                → NEG + GCS bucket
 
-      Without this, Pulumi attempts parallel deletion and GCP rejects it
-      with "resource is already being used by another resource" errors.
+      All depends_on chains are declared explicitly — Pulumi cannot always
+      infer deletion order from self_link string references alone.
 
-    DNS records required (add at your registrar after pulumi up):
-      A    <domain>  →  <frontend_ip output>
-      (TXT record for domain verification if prompted by GCP)
+    DNS records required (add at registrar after pulumi up):
+      A    DOMAIN      →  <frontend_ip output>
+      A    API_DOMAIN  →  <frontend_ip output>  (same IP — shared LB)
+
+    SSL cert provisioning:
+      Google-managed certs provision asynchronously after DNS propagates.
+      Adding API_DOMAIN to the cert triggers a replace (GCP does not allow
+      in-place domain changes) — expect a brief HTTPS disruption (~minutes)
+      while the new cert provisions. Status:
+        gcloud compute ssl-certificates describe <name> --global
     """
 
     # ── Bucket ────────────────────────────────────────────────────────────────
@@ -109,16 +112,15 @@ def create_frontend() -> FrontendOutputs:
 
     # ── Load Balancer ─────────────────────────────────────────────────────────
 
-    # Static global IP — your DNS A record points at this forever.
+    # Static global IP — both DNS A records (DOMAIN + API_DOMAIN) point here.
     # Global (not regional) because the HTTPS load balancer is global.
     ip = gcp.compute.GlobalAddress(
         "frontend-ip",
         name=f"{_NAME_PREFIX}-ip",
-        description="Static IP for the storyengine dev frontend load balancer",
+        description="Static IP for the storyengine frontend + API load balancer",
     )
 
-    # Backend bucket — the LB target that serves files from GCS.
-    # enable_cdn=False for now. Flip to True when caching is needed.
+    # Backend bucket — the LB target that serves static files from GCS.
     backend_bucket = gcp.compute.BackendBucket(
         "frontend-backend-bucket",
         name=f"{_NAME_PREFIX}-backend",
@@ -127,31 +129,91 @@ def create_frontend() -> FrontendOutputs:
         description="Serves static frontend assets from GCS",
     )
 
-    # URL map — routes all requests to the backend bucket.
-    # For a pure static site this is trivial: everything goes to the bucket.
+    # ── API routing (Serverless NEG + Backend Service) ─────────────────────────
+
+    # Serverless NEG — the bridge between the load balancer world (IPs/ports)
+    # and Cloud Run (no fixed IPs). Points at the Cloud Run service by name.
+    # Must be in the same region as the Cloud Run service.
+    neg = gcp.compute.RegionNetworkEndpointGroup(
+        "api-neg",
+        name=f"{_NAME_PREFIX}-api-neg",
+        network_endpoint_type="SERVERLESS",
+        region=REGION,
+        cloud_run=gcp.compute.RegionNetworkEndpointGroupCloudRunArgs(
+            service=service.name,
+        ),
+    )
+
+    # Backend Service — wraps the NEG and is referenced by the URL map.
+    # protocol=HTTPS because Cloud Run only accepts HTTPS.
+    # Must be deleted before the URL map on destroy (URL map references it).
+    backend_service = gcp.compute.BackendService(
+        "api-backend-service",
+        name=f"{_NAME_PREFIX}-api-backend",
+        protocol="HTTPS",
+        load_balancing_scheme="EXTERNAL",
+        backends=[
+            gcp.compute.BackendServiceBackendArgs(
+                group=neg.id,
+            )
+        ],
+        opts=pulumi.ResourceOptions(depends_on=[neg]),
+    )
+
+    # ── URL Map (host-based routing) ──────────────────────────────────────────
+
+    # Routes requests to the correct backend based on the Host: header.
+    # DOMAIN → GCS bucket (static frontend assets)
+    # API_DOMAIN → Cloud Run service (via Backend Service + NEG)
+    # Default fallback → GCS bucket (handles bare IP requests, healthchecks)
+    #
+    # depends_on both backend targets so Pulumi deletes those resources
+    # AFTER the URL map on destroy — GCP rejects deleting a backend while
+    # any URL map still references it.
     url_map = gcp.compute.URLMap(
         "frontend-url-map",
         name=f"{_NAME_PREFIX}-urlmap",
         default_service=backend_bucket.self_link,
-        description="Routes all traffic to the frontend GCS bucket",
+        host_rules=[
+            gcp.compute.URLMapHostRuleArgs(
+                hosts=[DOMAIN],
+                path_matcher="frontend",
+            ),
+            gcp.compute.URLMapHostRuleArgs(
+                hosts=[API_DOMAIN],
+                path_matcher="api",
+            ),
+        ],
+        path_matchers=[
+            gcp.compute.URLMapPathMatcherArgs(
+                name="frontend",
+                default_service=backend_bucket.self_link,
+            ),
+            gcp.compute.URLMapPathMatcherArgs(
+                name="api",
+                default_service=backend_service.self_link,
+            ),
+        ],
+        opts=pulumi.ResourceOptions(depends_on=[backend_bucket, backend_service]),
     )
 
-    # Google-managed SSL certificate — GCP provisions and auto-renews.
-    # Free. Provisioning takes 10-30 minutes after DNS propagates.
-    # Status check: gcloud compute ssl-certificates describe <name> --global
+    # Google-managed SSL certificate covering both domains.
+    # GCP provisions and auto-renews. Free.
+    # Trailing dot = fully-qualified domain name (GCP requirement).
+    # Provisioning takes 10-30 minutes after DNS propagates for both domains.
+    # Adding or removing a domain triggers a cert replace (not in-place update).
     ssl_cert = gcp.compute.ManagedSslCertificate(
         "frontend-ssl-cert",
         name=f"{_NAME_PREFIX}-cert",
         managed=gcp.compute.ManagedSslCertificateManagedArgs(
-            domains=[f"{DOMAIN}."],
+            domains=[f"{DOMAIN}.", f"{API_DOMAIN}."],
         ),
-        description=f"Google-managed SSL certificate for {DOMAIN}",
+        description=f"Google-managed SSL certificate for {DOMAIN} and {API_DOMAIN}",
     )
 
     # HTTPS proxy — terminates SSL using the managed cert.
     # depends_on url_map and ssl_cert explicitly so Pulumi deletes this proxy
-    # before either of them on destroy/replace (GCP rejects deleting a cert
-    # or url map while a proxy still references it).
+    # before either of them on destroy/replace.
     https_proxy = gcp.compute.TargetHttpsProxy(
         "frontend-https-proxy",
         name=f"{_NAME_PREFIX}-https-proxy",
@@ -161,9 +223,8 @@ def create_frontend() -> FrontendOutputs:
     )
 
     # Forwarding rule — binds the static IP + port 443 to the HTTPS proxy.
-    # depends_on the proxy explicitly so Pulumi deletes this forwarding rule
-    # before the proxy on destroy/replace (GCP rejects deleting a proxy while
-    # a forwarding rule still references it).
+    # depends_on the proxy explicitly so Pulumi deletes this rule before the
+    # proxy on destroy/replace.
     gcp.compute.GlobalForwardingRule(
         "frontend-https-forwarding-rule",
         name=f"{_NAME_PREFIX}-https-rule",
@@ -177,8 +238,7 @@ def create_frontend() -> FrontendOutputs:
 
     # ── HTTP → HTTPS redirect ─────────────────────────────────────────────────
 
-    # All port 80 traffic is redirected to HTTPS.
-    # Uses a separate URL map that returns a 301 redirect for every request.
+    # All port 80 traffic (both domains) is redirected to HTTPS.
     redirect_url_map = gcp.compute.URLMap(
         "frontend-redirect-url-map",
         name=f"{_NAME_PREFIX}-redirect-urlmap",
@@ -188,8 +248,6 @@ def create_frontend() -> FrontendOutputs:
         ),
     )
 
-    # depends_on redirect_url_map explicitly so Pulumi deletes this proxy
-    # before the url map on destroy/replace.
     http_proxy = gcp.compute.TargetHttpProxy(
         "frontend-http-proxy",
         name=f"{_NAME_PREFIX}-http-proxy",
@@ -197,8 +255,6 @@ def create_frontend() -> FrontendOutputs:
         opts=pulumi.ResourceOptions(depends_on=[redirect_url_map]),
     )
 
-    # depends_on the http proxy explicitly so Pulumi deletes this forwarding
-    # rule before the proxy on destroy/replace.
     gcp.compute.GlobalForwardingRule(
         "frontend-http-forwarding-rule",
         name=f"{_NAME_PREFIX}-http-rule",
@@ -214,4 +270,5 @@ def create_frontend() -> FrontendOutputs:
         bucket=bucket,
         ip_address=ip.address,
         url=f"https://{DOMAIN}",
+        api_url=f"https://{API_DOMAIN}",
     )

--- a/infra/components/frontend.py
+++ b/infra/components/frontend.py
@@ -204,11 +204,19 @@ def create_frontend(service: gcp.cloudrunv2.Service) -> FrontendOutputs:
     # Adding or removing a domain triggers a cert replace (not in-place update).
     ssl_cert = gcp.compute.ManagedSslCertificate(
         "frontend-ssl-cert",
-        name=f"{_NAME_PREFIX}-cert",
+        name=f"{_NAME_PREFIX}-cert-v2",  # GCP resource name kept as-is to avoid replace
         managed=gcp.compute.ManagedSslCertificateManagedArgs(
             domains=[f"{DOMAIN}.", f"{API_DOMAIN}."],
         ),
         description=f"Google-managed SSL certificate for {DOMAIN} and {API_DOMAIN}",
+        opts=pulumi.ResourceOptions(
+            # Create the new cert before deleting the old one on future domain
+            # changes — GCP rejects deleting a cert while a proxy references it.
+            # aliases reconciles the Pulumi logical name (frontend-ssl-cert-v2 →
+            # frontend-ssl-cert) as a state-only rename with no GCP operation.
+            delete_before_replace=False,
+            aliases=[pulumi.Alias(name="frontend-ssl-cert-v2")],
+        ),
     )
 
     # HTTPS proxy — terminates SSL using the managed cert.


### PR DESCRIPTION
## Overview

Eight commits across three themes: routing `api.dekatha.com` through the existing load balancer, security hardening, and making the infra reusable as a template for new projects.

All changes have been verified locally — `pulumi preview` shows zero unexpected resource changes after the refactor commits.

---

## 1. `api.dekatha.com` routing via shared load balancer

Rather than provisioning a separate API load balancer (~$36/month extra), `api.dekatha.com` is routed through the existing frontend load balancer using host-based URL map rules. Both domains share one Global IP, one SSL cert, one set of forwarding rules.

```
Single Global IP (136.110.212.53)
  │
  ▼
URL Map (host-based routing)
  ├─ app.dekatha.com  →  Backend Bucket  →  GCS (static frontend)
  └─ api.dekatha.com  →  Backend Service →  Serverless NEG  →  Cloud Run
```

**New GCP resources:**
- `RegionNetworkEndpointGroup` — serverless NEG wrapping the Cloud Run service
- `BackendService` — wraps the NEG, plugged into the URL map

**SSL cert:** now covers both domains. Uses `delete_before_replace=False` to create the new cert before deleting the old one — prevents the ordering failure where GCP rejects deleting a cert still referenced by the HTTPS proxy.

**DNS required (already done):**
```
A  app.dekatha.com  →  <new-ip>
A  api.dekatha.com  →  <new-ip>
```

**Decoupling note** (in `frontend.py` docstring): if a dedicated API LB is ever warranted, extract the NEG + BackendService + new GlobalAddress + new SSL cert into `components/backend_lb.py` and remove the api host rule from the URL map.

---

## 2. Security hardening

**Disable API docs in production**

FastAPI's `/docs`, `/redoc`, and `/openapi.json` expose the full endpoint schema to the public internet. Disabled when `ENV=production`.

- `backend/core/config.py` — add `env: str = "development"` field
- `backend/main.py` — `docs_url=None`, `redoc_url=None`, `openapi_url=None` when production
- `infra/components/cloudrun.py` — inject `ENV=production` as plain env var

Locally docs remain available at `/docs` — no `.env.local` change needed.

---

## 3. Infra as a template — zero hardcoded project-specific strings

Before this PR, switching to a new project required hunting down ~15 hardcoded `storyengine` references. After this PR, it's a 4-step checklist.

### What changed

| File | Change |
|---|---|
| `Pulumi.yaml` | `storyengine-infra:app: storyengine` as project-level default |
| `components/config.py` | `APP = _app.require("app")` — single source of truth |
| `Makefile` | `PULUMI_PROJECT` read from `Pulumi.yaml` via grep; `APP` + `PREFIX` derived from it; all `storyengine-$(STACK)` replaced with `$(PREFIX)`; `REGISTRY` reads from stack output |

### For a new project

1. Change `name:` in `Pulumi.yaml` → Makefile namespace updates automatically
2. Change `app:` value in `Pulumi.yaml` → all GCP resource names update
3. Update `Pulumi.main.yaml` key prefixes (one `sed` command)
4. Create a new GCS state bucket

No Makefile edits required.

### Verified

```
pulumi preview → 52 unchanged (no resource names drifted)
make -n deploy-backend → correct storyengine-main/backend:... image tag
make -n status → correct storyengine-main-* resource names
```

---

## 4. Pipeline and Makefile hardcode cleanup

**`deploy.yml`** — all domain-derived values now read from stack outputs:

```yaml
- name: Get stack outputs
  run: |
    echo "SERVICE_URL=$(pulumi stack output api_url)" >> $GITHUB_ENV
    echo "FRONTEND_BUCKET=$(pulumi stack output frontend_bucket)" >> $GITHUB_ENV
    echo "FRONTEND_URL=$(pulumi stack output frontend_url)" >> $GITHUB_ENV
```

`gcloud storage rsync` uses `gs://${{ env.FRONTEND_BUCKET }}`. Step summary uses `${{ env.SERVICE_URL }}` and `${{ env.FRONTEND_URL }}`. Zero hardcoded domain strings.

**`Makefile`** — new `make change-domain` target prints the exact ordered steps for switching domains (including what `make up` recreates, DNS instructions, cert provisioning wait). `make status` SSL cert lookup uses `--filter` instead of hardcoded cert name.

**A full domain change is now:**
1. Two lines in `Pulumi.main.yaml`
2. `make up`
3. Update DNS
4. `make deploy-frontend`

---

## 5. `infra/AGENT.md`

Comprehensive reference document for AI agents working in this directory. Covers: file map, layer dependency order, naming conventions, how to add secrets/env vars/new GCP resources, DB password pattern, `.env.local` structure, reading stack outputs, key nuanced decisions, what not to touch, operational quick reference, new project bootstrap guide.

---

## Reviewing

| File | What to look at |
|---|---|
| `infra/components/frontend.py` | URL map restructure, NEG + BackendService, cert `delete_before_replace`, decoupling note |
| `infra/components/config.py` | `APP = _app.require("app")` |
| `infra/Pulumi.yaml` | `app` config default |
| `infra/Makefile` | `PULUMI_PROJECT` + `PREFIX` vars, `change-domain` target |
| `.github/workflows/deploy.yml` | Consolidated stack outputs step |
| `backend/main.py` + `backend/core/config.py` | Docs disabled in production |
| `infra/AGENT.md` | New project bootstrap section |