### PR TITLE
feat(scene-engine): panel extraction and rendering steps

### DIFF
--- a/backend/core/story_engine/api/v2/panels.py
+++ b/backend/core/story_engine/api/v2/panels.py
@@ -30,6 +30,7 @@ from ...schemas.edit_event import EditEventResponseSchema
 from ...schemas.image import ImageResponseSchema
 from ...schemas.panel import (
     PanelGenerateRequest,
+    PanelRefineRequest,
     PanelRenderEditRequest,
     PanelRenderReferencesSchema,
     PanelResponseSchema,
@@ -188,6 +189,50 @@ async def generate_panel(
         raise HTTPException(
             status_code=500,
             detail="An unexpected error occurred while generating the panel",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Story 55 — Refine panel attributes via user instruction
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/project/{project_id}/story/{story_id}/panel/{panel_id}/refine",
+    status_code=200,
+)
+async def refine_panel(
+    project_id: uuid.UUID,
+    story_id: uuid.UUID,
+    panel_id: uuid.UUID,
+    body: PanelRefineRequest,
+    user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
+    service: Annotated[PanelService, Depends(get_panel_service)],
+) -> PanelRenderReferencesSchema:
+    """Refine a panel's attributes using a user instruction.
+
+    The panel must already have content (i.e. generate must have been called first).
+    Returns the full panel payload with updated attributes. Mirrors POST .../character/:id/refine.
+    """
+    try:
+        panel = await service.refine_panel(
+            project_id=project_id,
+            story_id=story_id,
+            panel_id=panel_id,
+            instruction=body.instruction,
+        )
+        render = await service.get_canonical_panel_render(panel_id)
+        refs = await service.get_panel_reference_images(panel_id)
+        return _build_panel_full(panel, render, refs)
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except NoCharactersError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except Exception as e:
+        logger.exception(f"Unexpected error refining panel {panel_id}: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail="An unexpected error occurred while refining the panel",
         )
 
 

--- a/backend/core/story_engine/api/v2/panels.py
+++ b/backend/core/story_engine/api/v2/panels.py
@@ -206,20 +206,22 @@ async def render_panel(
     panel_id: uuid.UUID,
     user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     service: Annotated[PanelService, Depends(get_panel_service)],
-) -> ImageResponseSchema:
+) -> PanelRenderReferencesSchema:
     """Render a panel image via fal and store in GCS.
 
-    Returns the created Image ORM object serialized as ImageResponseSchema.
-    The panel's updated canonical render is visible on subsequent GET /panel/{id} calls.
+    Returns the full panel payload including the new canonical render and
+    reference images — mirrors render_character which returns the full
+    CharacterRenderReferencesSchema so the client can update its cache slot.
     """
     try:
-        image = await service.render_panel(
+        panel, image = await service.render_panel(
             user_id=user_id,
             project_id=project_id,
             story_id=story_id,
             panel_id=panel_id,
         )
-        return ImageResponseSchema.model_validate(image)
+        refs = await service.get_panel_reference_images(panel_id)
+        return _build_panel_full(panel, image, refs)
     except NotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:

--- a/backend/core/story_engine/api/v2/panels.py
+++ b/backend/core/story_engine/api/v2/panels.py
@@ -24,12 +24,12 @@ from ...exceptions import (
     NoCharactersError,
     NoStoryTextError,
     NotFoundError,
+    PanelAlreadyGeneratedError,
     UploadImageError,
 )
 from ...schemas.edit_event import EditEventResponseSchema
 from ...schemas.image import ImageResponseSchema
 from ...schemas.panel import (
-    PanelGenerateRequest,
     PanelRefineRequest,
     PanelRenderEditRequest,
     PanelRenderReferencesSchema,
@@ -164,22 +164,22 @@ async def generate_panel(
     panel_id: uuid.UUID,
     user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     service: Annotated[PanelService, Depends(get_panel_service)],
-    body: PanelGenerateRequest | None = None,
 ) -> PanelRenderReferencesSchema:
-    """Generate or regenerate content for a single panel (Decision 8).
+    """Generate content for a single panel for the first time.
 
-    First call (empty attributes): generates from story context.
-    Subsequent calls: refines using the optional instruction.
+    Only valid when the panel has no content yet. Returns 400 if the panel
+    already has generated content — use POST .../refine to update it.
     """
     try:
         panel = await service.generate_panel(
             project_id=project_id,
             story_id=story_id,
             panel_id=panel_id,
-            instruction=body.instruction if body is not None else None,
         )
         render = await service.get_canonical_panel_render(panel_id)
         return _build_panel_full(panel, render)
+    except PanelAlreadyGeneratedError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except NotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except NoCharactersError as e:

--- a/backend/core/story_engine/exceptions.py
+++ b/backend/core/story_engine/exceptions.py
@@ -117,3 +117,9 @@ class UploadImageError(BaseError):
     """Error uploading image to bucket."""
 
     pass
+
+
+class PanelAlreadyGeneratedError(BaseError):
+    """Panel already has generated content — use /refine to update it."""
+
+    pass

--- a/backend/core/story_engine/models/edit_event.py
+++ b/backend/core/story_engine/models/edit_event.py
@@ -28,6 +28,7 @@ class EditEventOperationType(StrEnum):
     RENDER_CHARACTER_EDIT = "render_character_edit"
     SET_CANONICAL_RENDER = "set_canonical_render"
     GENERATE_PANEL = "generate_panel"
+    REFINE_PANEL = "refine_panel"
     RENDER_PANEL = "render_panel"
     RENDER_PANEL_EDIT = "render_panel_edit"
 

--- a/backend/core/story_engine/repository/panel_repository.py
+++ b/backend/core/story_engine/repository/panel_repository.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import asc, select
+from sqlalchemy import asc, delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models import Panel
@@ -61,6 +61,22 @@ class PanelRepository:
             raise NotFoundError(f"Panel {panel_id} not found in story {story_id}")
         panel.canonical_render_id = image_id
         return panel
+
+    async def replace_panel_characters(
+        self, panel_id: uuid.UUID, character_ids: list[uuid.UUID]
+    ) -> None:
+        """Replace all panel_character rows for a panel atomically.
+
+        Deletes every existing join row for the panel, then inserts fresh rows
+        for each UUID in character_ids. Safe to call when the table is empty
+        (first-gen) or when rows already exist (regen/refine). Caller is
+        responsible for flushing/committing the surrounding transaction.
+        """
+        await self.db.execute(
+            delete(PanelCharacter).where(PanelCharacter.panel_id == panel_id)
+        )
+        for character_id in character_ids:
+            self.db.add(PanelCharacter(panel_id=panel_id, character_id=character_id))
 
     async def delete_panel(self, panel_id: uuid.UUID, story_id: uuid.UUID) -> None:
         panel = await self.get_panel(panel_id, story_id)

--- a/backend/core/story_engine/schemas/panel.py
+++ b/backend/core/story_engine/schemas/panel.py
@@ -80,12 +80,14 @@ class SetCanonicalPanelRenderRequest(AliasedBaseModel):
 
 
 class PanelGenerateRequest(AliasedBaseModel):
-    """Request body for the single-panel generate/regenerate endpoint.
+    """Request body for the single-panel first-generation endpoint.
 
-    instruction is optional — absent on first generation, present on regeneration.
+    No fields required — the panel is generated from story context alone.
+    Kept as an explicit schema (rather than dropping the body entirely) so
+    the endpoint signature is consistent and extensible.
     """
 
-    instruction: str | None = None
+    pass
 
 
 class PanelRefineRequest(AliasedBaseModel):

--- a/backend/core/story_engine/schemas/panel.py
+++ b/backend/core/story_engine/schemas/panel.py
@@ -88,6 +88,16 @@ class PanelGenerateRequest(AliasedBaseModel):
     instruction: str | None = None
 
 
+class PanelRefineRequest(AliasedBaseModel):
+    """Request body for POST .../panel/:id/refine.
+
+    instruction is required — refine always needs user direction.
+    Mirrors CharacterRefineRequest.
+    """
+
+    instruction: str
+
+
 class PanelRenderEditRequest(AliasedBaseModel):
     """Request body for editing an existing panel render via fal image-edit model."""
 

--- a/backend/core/story_engine/service/panel_service.py
+++ b/backend/core/story_engine/service/panel_service.py
@@ -570,7 +570,7 @@ class PanelService:
         project_id: uuid.UUID,
         story_id: uuid.UUID,
         panel_id: uuid.UUID,
-    ) -> ImageModel:
+    ) -> tuple[Panel, ImageModel]:
         """Render a panel image via fal and store in GCS.
 
         Flow (Decision 16):
@@ -580,7 +580,7 @@ class PanelService:
           4. Download fal output bytes, upload to GCS.
           5. Create Image row (target_id=panel_id, discriminator_key=panel_render).
           6. Create EditEvent(RENDER_PANEL, SUCCEEDED).
-          7. Return the Image ORM object.
+          7. Return (panel, image) — mirrors render_character return signature.
         """
         story = await self.repository_v2.story.get_story(project_id, story_id)
         if story is None:
@@ -694,7 +694,14 @@ class PanelService:
             )
             await self.db.commit()
             await self.db.refresh(image_model)
-            return image_model
+
+            # Refresh panel so canonical_render_id is up-to-date
+            refreshed_panel = await self.repository_v2.panel.get_panel(
+                panel_id, story_id
+            )
+            if refreshed_panel is None:
+                raise NotFoundError(f"Panel {panel_id} not found in story {story_id}")
+            return refreshed_panel, image_model
 
         except Exception:
             await self.repository_v2.edit_event.update_edit_event(

--- a/backend/core/story_engine/service/panel_service.py
+++ b/backend/core/story_engine/service/panel_service.py
@@ -242,6 +242,93 @@ class PanelService:
             await self.db.commit()
             raise
 
+    # -----------------------------------------------------------------------
+    # refine_panel (user-directed attribute update — Story 55)
+    # -----------------------------------------------------------------------
+
+    async def refine_panel(
+        self,
+        project_id: uuid.UUID,
+        story_id: uuid.UUID,
+        panel_id: uuid.UUID,
+        instruction: str,
+    ) -> Panel:
+        """Refine a panel's attributes using a user instruction.
+
+        Requires the panel to have already been generated (non-empty attributes).
+        Calls the LLM regeneration branch with the provided instruction and
+        persists the updated attributes under a REFINE_PANEL edit event.
+        Mirrors refine_character in character_service.py.
+        """
+        story = await self.repository_v2.story.get_story(project_id, story_id)
+        if story is None:
+            raise NotFoundError(f"Story {story_id} not found")
+
+        panel = await self.repository_v2.panel.get_panel(panel_id, story_id)
+        if panel is None:
+            raise NotFoundError(f"Panel {panel_id} not found in story {story_id}")
+
+        input_attrs = dict(panel.attributes)
+        if not input_attrs:
+            raise NotFoundError(
+                f"Panel {panel_id} has no content yet — generate it before refining"
+            )
+
+        characters = await self.repository_v2.character.get_all_characters_for_a_story(
+            story_id
+        )
+        character_slugs = [c.slug for c in characters]
+        if not character_slugs:
+            raise NoCharactersError(
+                f"Story {story_id} has no characters — extract characters first"
+            )
+
+        # TX1: create PENDING edit event
+        edit_event = EditEvent.create_edit_event(
+            project_id=project_id,
+            target_type=EditEventTargetType.PANEL,
+            target_id=panel_id,
+            operation_type=EditEventOperationType.REFINE_PANEL,
+            user_instruction=instruction,
+            status=EditEventStatus.PENDING,
+            input_snapshot=input_attrs,
+        )
+        await self.repository_v2.edit_event.add_edit_event_to_db(edit_event)
+        await self.db.flush()
+        edit_event_id = edit_event.id
+        await self.db.commit()
+
+        try:
+            panel_content = await self._regenerate_panel(
+                existing_attributes=input_attrs,
+                instruction=instruction,
+                character_slugs=character_slugs,
+            )
+            new_attributes = {
+                "background": panel_content.background,
+                "dialogue": panel_content.dialogue,
+                "characters": panel_content.characters,
+            }
+
+            # TX2: persist refined attributes + mark event SUCCEEDED
+            panel.attributes = new_attributes
+            panel.source_event_id = edit_event_id
+            await self.repository_v2.edit_event.update_edit_event(
+                edit_event_id,
+                EditEventStatus.SUCCEEDED,
+                output_snapshot=new_attributes,
+            )
+            await self.db.commit()
+            await self.db.refresh(panel)
+            return panel
+
+        except Exception:
+            await self.repository_v2.edit_event.update_edit_event(
+                edit_event_id, EditEventStatus.FAILED
+            )
+            await self.db.commit()
+            raise
+
     async def _generate_panel_first_time(
         self, story_text: str, order_index: int, character_slugs: list[str]
     ) -> PanelContent:

--- a/backend/core/story_engine/service/panel_service.py
+++ b/backend/core/story_engine/service/panel_service.py
@@ -25,6 +25,7 @@ from ..exceptions import (
     NoCharactersError,
     NoStoryTextError,
     NotFoundError,
+    PanelAlreadyGeneratedError,
 )
 from ..models import EditEvent, Panel
 from ..models.edit_event import (
@@ -156,13 +157,15 @@ class PanelService:
         project_id: uuid.UUID,
         story_id: uuid.UUID,
         panel_id: uuid.UUID,
-        instruction: str | None,
     ) -> Panel:
-        """Generate or regenerate content for a single panel (Decision 8).
+        """Generate content for a single panel for the first time.
 
-        First call (empty attributes): generates from story context.
-        Subsequent calls (populated attributes): refines using instruction.
-        Operation type is always GENERATE_PANEL regardless.
+        Only valid when the panel has no content yet (empty attributes).
+        Raises PanelAlreadyGeneratedError if the panel already has content —
+        callers should use /refine to update an already-generated panel.
+
+        Creates panel_character join rows for each character the LLM assigns,
+        mirroring the bulk generate_panels flow.
         """
         story = await self.repository_v2.story.get_story(project_id, story_id)
         if story is None:
@@ -172,18 +175,24 @@ class PanelService:
         if panel is None:
             raise NotFoundError(f"Panel {panel_id} not found in story {story_id}")
 
+        # Guard: first-generation only
+        if panel.attributes:
+            raise PanelAlreadyGeneratedError(
+                f"Panel {panel_id} already has content — use /refine to update it"
+            )
+
         # Load characters to build slug list for constrained LLM extraction
         characters = await self.repository_v2.character.get_all_characters_for_a_story(
             story_id
         )
-        character_slugs = [c.slug for c in characters]
+        slug_to_id: dict[str, uuid.UUID] = {c.slug: c.id for c in characters}
+        character_slugs = list(slug_to_id.keys())
         if not character_slugs:
             raise NoCharactersError(
                 f"Story {story_id} has no characters — extract characters before generating panels"
             )
 
-        # Snapshot all ORM attribute values before any commit (ORM objects expire after commit)
-        input_attrs = dict(panel.attributes)
+        # Snapshot order_index and story_text before any commit
         panel_order_index = panel.order_index
         story_text = story.story_text
 
@@ -193,9 +202,9 @@ class PanelService:
             target_type=EditEventTargetType.PANEL,
             target_id=panel_id,
             operation_type=EditEventOperationType.GENERATE_PANEL,
-            user_instruction=instruction or "",
+            user_instruction="",
             status=EditEventStatus.PENDING,
-            input_snapshot=input_attrs,
+            input_snapshot={},
         )
         await self.repository_v2.edit_event.add_edit_event_to_db(edit_event)
         await self.db.flush()
@@ -203,29 +212,28 @@ class PanelService:
         await self.db.commit()
 
         try:
-            is_first_generation = not input_attrs
-            if is_first_generation:
-                panel_content = await self._generate_panel_first_time(
-                    story_text=story_text,
-                    order_index=panel_order_index,
-                    character_slugs=character_slugs,
-                )
-            else:
-                panel_content = await self._regenerate_panel(
-                    existing_attributes=input_attrs,
-                    instruction=instruction or "Regenerate this panel.",
-                    character_slugs=character_slugs,
-                )
-
+            panel_content = await self._generate_panel_first_time(
+                story_text=story_text,
+                order_index=panel_order_index,
+                character_slugs=character_slugs,
+            )
             new_attributes = {
                 "background": panel_content.background,
                 "dialogue": panel_content.dialogue,
                 "characters": panel_content.characters,
             }
 
-            # TX2: update panel attributes + mark event SUCCEEDED
+            # TX2: update panel attributes + create join rows + mark event SUCCEEDED
             panel.attributes = new_attributes
             panel.source_event_id = edit_event_id
+            resolved_ids = [
+                slug_to_id[slug]
+                for slug in panel_content.characters
+                if slug in slug_to_id
+            ]
+            await self.repository_v2.panel.replace_panel_characters(
+                panel_id, resolved_ids
+            )
             await self.repository_v2.edit_event.update_edit_event(
                 edit_event_id,
                 EditEventStatus.SUCCEEDED,
@@ -277,7 +285,8 @@ class PanelService:
         characters = await self.repository_v2.character.get_all_characters_for_a_story(
             story_id
         )
-        character_slugs = [c.slug for c in characters]
+        slug_to_id: dict[str, uuid.UUID] = {c.slug: c.id for c in characters}
+        character_slugs = list(slug_to_id.keys())
         if not character_slugs:
             raise NoCharactersError(
                 f"Story {story_id} has no characters — extract characters first"
@@ -310,9 +319,17 @@ class PanelService:
                 "characters": panel_content.characters,
             }
 
-            # TX2: persist refined attributes + mark event SUCCEEDED
+            # TX2: persist refined attributes + reconcile join table + mark SUCCEEDED
             panel.attributes = new_attributes
             panel.source_event_id = edit_event_id
+            resolved_ids = [
+                slug_to_id[slug]
+                for slug in panel_content.characters
+                if slug in slug_to_id
+            ]
+            await self.repository_v2.panel.replace_panel_characters(
+                panel_id, resolved_ids
+            )
             await self.repository_v2.edit_event.update_edit_event(
                 edit_event_id,
                 EditEventStatus.SUCCEEDED,

--- a/backend/core/story_engine/service/panel_service.py
+++ b/backend/core/story_engine/service/panel_service.py
@@ -851,9 +851,36 @@ class PanelService:
 
         gcs_service = get_gcs_upload_service()
         source_signed_url, _ = gcs_service.generate_signed_url(source_image.object_key)
+
+        # URL order: [source, ...character_renders, optional_reference]
+        # Source anchors the edit; character renders enforce consistency;
+        # optional reference acts as a style guide.
         image_urls = [source_signed_url]
 
-        input_snapshot: dict[str, str] = {"source_image_id": str(source_image_id)}
+        # Resolve character renders — same block as render_panel
+        character_ids = await self.repository_v2.panel.get_character_ids_for_panel(
+            panel_id
+        )
+        character_render_ids: list[str] = []
+        for character_id in character_ids:
+            character_render = await self.repository_v2.image.get_canonical_render(
+                target_id=character_id,
+                discriminator_key=ImageDiscriminatorKey.CHARACTER_RENDER,
+            )
+            if character_render is None:
+                logger.warning(
+                    f"Character {character_id} has no canonical render — "
+                    f"skipping for panel {panel_id} render/edit"
+                )
+                continue
+            signed_url, _ = gcs_service.generate_signed_url(character_render.object_key)
+            image_urls.append(signed_url)
+            character_render_ids.append(str(character_render.id))
+
+        input_snapshot: dict[str, object] = {
+            "source_image_id": str(source_image_id),
+            "character_render_ids": character_render_ids,
+        }
 
         if reference_image_id is not None:
             reference_image = await self.repository_v2.image.get_image(

--- a/backend/tests/story_engine/test_panel_refine_api.py
+++ b/backend/tests/story_engine/test_panel_refine_api.py
@@ -9,6 +9,9 @@ Test invariants:
   3. 404 — panel does not exist
   4. 404 — panel exists but has no attributes yet (must generate before refining)
   5. 401 — no auth token
+  6. refine with a new character added → panel_character row created
+  7. refine with a character removed → stale panel_character row deleted
+  8. refine with unchanged character list → join rows unchanged
 """
 
 import uuid
@@ -26,6 +29,7 @@ from core.story_engine.models.edit_event import (
     EditEventOperationType,
     EditEventStatus,
 )
+from core.story_engine.models.panel_character import PanelCharacter
 
 _jwt = JWTTokenManager()
 
@@ -204,3 +208,144 @@ async def test_refine_panel_401_no_token(
         json={"instruction": "Make it better."},
     )
     assert response.status_code == 401
+
+
+async def test_refine_panel_adds_panel_character_row_for_new_character(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+) -> None:
+    """refine with a new character in the LLM response creates the panel_character row."""
+    # Panel starts with no characters
+    panel = Panel.create(
+        story_id=story.id,
+        order_index=0,
+        attributes={"background": "Forest", "dialogue": "Hi.", "characters": []},
+    )
+    db_session.add(panel)
+    await db_session.commit()
+
+    # LLM returns the character as newly added
+    mock_response = _mock_regenerate_response()
+    mock_response.characters = [character.slug]  # type: ignore[attr-defined]
+
+    with patch(
+        "core.story_engine.service.panel_service.instructor_client.chat.completions.create",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        response = await api_client.post(
+            _url(project.id, story.id, panel.id),
+            json={"instruction": f"Add {character.slug} to the scene."},
+            headers=_auth_headers(user.id),
+        )
+
+    assert response.status_code == 200
+
+    result = await db_session.execute(
+        select(PanelCharacter).where(PanelCharacter.panel_id == panel.id)
+    )
+    rows = list(result.scalars().all())
+    assert len(rows) == 1
+    assert rows[0].character_id == character.id
+
+
+async def test_refine_panel_removes_panel_character_row_for_dropped_character(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+) -> None:
+    """refine with character removed from LLM response deletes the panel_character row."""
+    panel = Panel.create(
+        story_id=story.id,
+        order_index=0,
+        attributes={
+            "background": "Forest",
+            "dialogue": "Hi.",
+            "characters": [character.slug],
+        },
+    )
+    db_session.add(panel)
+    await db_session.flush()
+
+    # Pre-existing join row
+    db_session.add(PanelCharacter(panel_id=panel.id, character_id=character.id))
+    await db_session.commit()
+
+    # LLM returns no characters — character was removed
+    mock_response = _mock_regenerate_response()
+    mock_response.characters = []  # type: ignore[attr-defined]
+
+    with patch(
+        "core.story_engine.service.panel_service.instructor_client.chat.completions.create",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        response = await api_client.post(
+            _url(project.id, story.id, panel.id),
+            json={"instruction": "Remove all characters from the scene."},
+            headers=_auth_headers(user.id),
+        )
+
+    assert response.status_code == 200
+
+    result = await db_session.execute(
+        select(PanelCharacter).where(PanelCharacter.panel_id == panel.id)
+    )
+    rows = list(result.scalars().all())
+    assert len(rows) == 0
+
+
+async def test_refine_panel_unchanged_character_list_keeps_join_rows(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+) -> None:
+    """refine with unchanged character list leaves panel_character rows intact."""
+    panel = Panel.create(
+        story_id=story.id,
+        order_index=0,
+        attributes={
+            "background": "Forest",
+            "dialogue": "Hi.",
+            "characters": [character.slug],
+        },
+    )
+    db_session.add(panel)
+    await db_session.flush()
+
+    db_session.add(PanelCharacter(panel_id=panel.id, character_id=character.id))
+    await db_session.commit()
+
+    # LLM returns the same character
+    mock_response = _mock_regenerate_response()
+    mock_response.characters = [character.slug]  # type: ignore[attr-defined]
+
+    with patch(
+        "core.story_engine.service.panel_service.instructor_client.chat.completions.create",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        response = await api_client.post(
+            _url(project.id, story.id, panel.id),
+            json={"instruction": "Make the dialogue more dramatic."},
+            headers=_auth_headers(user.id),
+        )
+
+    assert response.status_code == 200
+
+    result = await db_session.execute(
+        select(PanelCharacter).where(PanelCharacter.panel_id == panel.id)
+    )
+    rows = list(result.scalars().all())
+    assert len(rows) == 1
+    assert rows[0].character_id == character.id

--- a/backend/tests/story_engine/test_panel_refine_api.py
+++ b/backend/tests/story_engine/test_panel_refine_api.py
@@ -1,0 +1,206 @@
+"""
+Tests for POST .../panel/{panel_id}/refine.
+
+Test invariants:
+  1. 200 — refine updates panel attributes based on instruction; returns
+     PanelRenderReferencesSchema with updated panel.attributes
+  2. 200 — REFINE_PANEL edit event created with SUCCEEDED status, correct
+     input_snapshot (pre-refine attributes) and output_snapshot (post-refine)
+  3. 404 — panel does not exist
+  4. 404 — panel exists but has no attributes yet (must generate before refining)
+  5. 401 — no auth token
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.auth.managers.jwt import JWTTokenManager
+from core.auth.models.user import User
+from core.story_engine.models import Character, Panel, Project, Story
+from core.story_engine.models.edit_event import (
+    EditEvent,
+    EditEventOperationType,
+    EditEventStatus,
+)
+
+_jwt = JWTTokenManager()
+
+
+def _auth_headers(user_id: uuid.UUID) -> dict[str, str]:
+    token = _jwt.create_access_token(user_id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _url(project_id: uuid.UUID, story_id: uuid.UUID, panel_id: uuid.UUID) -> str:
+    return (
+        f"/api/comic-builder/v2/project/{project_id}"
+        f"/story/{story_id}/panel/{panel_id}/refine"
+    )
+
+
+def _mock_regenerate_response() -> object:
+    """Minimal instructor response for _regenerate_panel."""
+    from core.story_engine.schemas.panel import PanelContent
+
+    return PanelContent(
+        background="A refined moonlit forest",
+        dialogue="We must move quickly.",
+        characters=[],
+    )
+
+
+async def test_refine_panel_200_updates_attributes(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+) -> None:
+    """200 — attributes are updated; response contains updated panel.attributes."""
+    panel = Panel.create(
+        story_id=story.id,
+        order_index=0,
+        attributes={
+            "background": "Original dark forest",
+            "dialogue": "Hello.",
+            "characters": [character.slug],
+        },
+    )
+    db_session.add(panel)
+    await db_session.commit()
+
+    mock_response = _mock_regenerate_response()
+
+    with patch(
+        "core.story_engine.service.panel_service.instructor_client.chat.completions.create",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        response = await api_client.post(
+            _url(project.id, story.id, panel.id),
+            json={"instruction": "Make the scene more dramatic."},
+            headers=_auth_headers(user.id),
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+
+    # Panel data is nested under "panel" key
+    assert body["panel"]["id"] == str(panel.id)
+    assert body["panel"]["attributes"]["background"] == "A refined moonlit forest"
+    assert body["panel"]["attributes"]["dialogue"] == "We must move quickly."
+
+    # Verify DB was updated
+    await db_session.refresh(panel)
+    assert panel.attributes["background"] == "A refined moonlit forest"
+
+
+async def test_refine_panel_200_creates_refine_panel_edit_event(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+) -> None:
+    """200 — REFINE_PANEL edit event created with SUCCEEDED status and correct snapshots."""
+    original_attrs = {
+        "background": "Original dark forest",
+        "dialogue": "Hello.",
+        "characters": [character.slug],
+    }
+    panel = Panel.create(
+        story_id=story.id,
+        order_index=0,
+        attributes=original_attrs,
+    )
+    db_session.add(panel)
+    await db_session.commit()
+
+    mock_response = _mock_regenerate_response()
+
+    with patch(
+        "core.story_engine.service.panel_service.instructor_client.chat.completions.create",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        response = await api_client.post(
+            _url(project.id, story.id, panel.id),
+            json={"instruction": "Make the scene more dramatic."},
+            headers=_auth_headers(user.id),
+        )
+
+    assert response.status_code == 200
+
+    result = await db_session.execute(
+        select(EditEvent).where(
+            EditEvent.target_id == panel.id,
+            EditEvent.operation_type == EditEventOperationType.REFINE_PANEL,
+        )
+    )
+    event = result.scalar_one_or_none()
+    assert event is not None
+    assert event.status == EditEventStatus.SUCCEEDED
+    assert event.user_instruction == "Make the scene more dramatic."
+    # input_snapshot captures the pre-refine attributes
+    assert event.input_snapshot == original_attrs
+    # output_snapshot captures the post-refine attributes
+    assert event.output_snapshot is not None
+    assert event.output_snapshot["background"] == "A refined moonlit forest"
+
+
+async def test_refine_panel_404_panel_not_found(
+    api_client: AsyncClient,
+    user: User,
+    project: Project,
+    story: Story,
+) -> None:
+    """404 when the panel does not exist."""
+    response = await api_client.post(
+        _url(project.id, story.id, uuid.uuid4()),
+        json={"instruction": "Make it better."},
+        headers=_auth_headers(user.id),
+    )
+    assert response.status_code == 404
+
+
+async def test_refine_panel_404_panel_not_yet_generated(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    user: User,
+    project: Project,
+    story: Story,
+) -> None:
+    """404 when panel exists but has no attributes (cannot refine before generating)."""
+    panel = Panel.create(
+        story_id=story.id,
+        order_index=0,
+        attributes={},  # empty — not yet generated
+    )
+    db_session.add(panel)
+    await db_session.commit()
+
+    response = await api_client.post(
+        _url(project.id, story.id, panel.id),
+        json={"instruction": "Make it better."},
+        headers=_auth_headers(user.id),
+    )
+    assert response.status_code == 404
+
+
+async def test_refine_panel_401_no_token(
+    api_client: AsyncClient,
+    project: Project,
+    story: Story,
+) -> None:
+    """401 when no auth token is provided."""
+    response = await api_client.post(
+        _url(project.id, story.id, uuid.uuid4()),
+        json={"instruction": "Make it better."},
+    )
+    assert response.status_code == 401

--- a/backend/tests/story_engine/test_panel_render_edit_api.py
+++ b/backend/tests/story_engine/test_panel_render_edit_api.py
@@ -7,21 +7,27 @@ Test invariants (fixture-backed, no fal/GCS):
   3. Returns 404 when the story ID does not exist.
   4. Returns 404 when source_image_id does not exist.
   5. Returns 404 when source_image_id belongs to a different panel.
-
-Happy-path (201 + correct ImageResponseSchema shape) requires a live fal call
-and is covered by manual integration tests.
+  6. Character canonical renders are included in the fal image_urls, and
+     character_render_ids appear in the edit event input_snapshot.
 """
 
 import uuid
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from httpx import AsyncClient
+from PIL import Image as PILImage
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.auth.managers.jwt import JWTTokenManager
 from core.auth.models.user import User
-from core.story_engine.models import Panel, Project, Story
+from core.story_engine.models import Character, Panel, Project, Story
+from core.story_engine.models.edit_event import EditEvent, EditEventOperationType
 from core.story_engine.models.image import Image as ImageModel
 from core.story_engine.models.image import ImageContentType, ImageDiscriminatorKey
+from core.story_engine.models.panel_character import PanelCharacter
+from core.story_engine.service.image_service import StorageReceipt
 
 _jwt = JWTTokenManager()
 
@@ -175,3 +181,116 @@ async def test_render_panel_edit_404_source_image_wrong_panel(
         headers=_auth_headers(user.id),
     )
     assert response.status_code == 404
+
+
+async def test_render_panel_edit_includes_character_renders_in_fal_call(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+) -> None:
+    """Character canonical renders are passed to fal and recorded in input_snapshot."""
+    panel = _make_panel(story)
+    db_session.add(panel)
+    await db_session.flush()
+
+    # Assign the character to the panel via the join table
+    db_session.add(PanelCharacter(panel_id=panel.id, character_id=character.id))
+
+    # Source panel render image
+    source_image = _make_render_image(project, user, panel, object_key="panel/src.jpg")
+    db_session.add(source_image)
+
+    # Character canonical render image
+    character_render = ImageModel.create(
+        project_id=project.id,
+        user_id=user.id,
+        target_id=character.id,
+        width=512,
+        height=512,
+        content_type=ImageContentType.JPEG,
+        object_key="character/render.jpg",
+        bucket="test-bucket",
+        size_bytes=2048,
+        discriminator_key=ImageDiscriminatorKey.CHARACTER_RENDER,
+    )
+    db_session.add(character_render)
+    await db_session.commit()
+
+    # Build a minimal valid JPEG for the fal response download
+    buf = BytesIO()
+    PILImage.new("RGB", (1, 1), color=(0, 0, 0)).save(buf, format="JPEG")
+    jpeg_bytes = buf.getvalue()
+
+    mock_fal_response = {"images": [{"url": "https://fal.ai/result.jpg"}]}
+    mock_receipt = StorageReceipt(
+        object_key=f"{project.id}/panel/{panel.id}/renders/edit-key",
+        bucket="test-bucket",
+    )
+
+    mock_httpx_resp = MagicMock()
+    mock_httpx_resp.content = jpeg_bytes
+    mock_httpx_resp.headers = {"content-type": "image/jpeg"}
+    mock_httpx_resp.raise_for_status = MagicMock()
+    mock_httpx_ctx = AsyncMock()
+    mock_httpx_ctx.__aenter__ = AsyncMock(return_value=mock_httpx_ctx)
+    mock_httpx_ctx.__aexit__ = AsyncMock(return_value=False)
+    mock_httpx_ctx.get = AsyncMock(return_value=mock_httpx_resp)
+
+    captured_fal_args: dict = {}
+
+    async def _capture_fal(**kwargs: object) -> dict:
+        captured_fal_args.update(kwargs)
+        return mock_fal_response
+
+    # GCSUploadService is accessed via get_gcs_upload_service() — mock the
+    # returned instance so generate_signed_url and upload are both controlled.
+    mock_gcs = MagicMock()
+    mock_gcs.generate_signed_url.side_effect = lambda object_key: (
+        f"https://signed/{object_key}",
+        None,
+    )
+    mock_gcs.upload.return_value = mock_receipt
+
+    with (
+        patch(
+            "core.story_engine.service.panel_service.get_gcs_upload_service",
+            return_value=mock_gcs,
+        ),
+        patch(
+            "core.story_engine.service.panel_service.fal_async_client.subscribe",
+            side_effect=_capture_fal,
+        ),
+        patch(
+            "core.story_engine.service.panel_service.httpx.AsyncClient",
+            return_value=mock_httpx_ctx,
+        ),
+    ):
+        response = await api_client.post(
+            _edit_url(project.id, story.id, panel.id),
+            json=_body(source_image.id),
+            headers=_auth_headers(user.id),
+        )
+
+    assert response.status_code == 201
+
+    # fal received both the source image URL and the character render URL
+    fal_image_urls: list[str] = captured_fal_args.get("arguments", {}).get(
+        "image_urls", []
+    )
+    assert len(fal_image_urls) == 2
+    assert "https://signed/panel/src.jpg" in fal_image_urls
+    assert "https://signed/character/render.jpg" in fal_image_urls
+
+    # input_snapshot records character_render_ids
+    event_result = await db_session.execute(
+        select(EditEvent).where(
+            EditEvent.target_id == panel.id,
+            EditEvent.operation_type == EditEventOperationType.RENDER_PANEL_EDIT,
+        )
+    )
+    event = event_result.scalar_one()
+    assert event.input_snapshot is not None
+    assert str(character_render.id) in event.input_snapshot["character_render_ids"]

--- a/backend/tests/story_engine/test_story50_generate_panel.py
+++ b/backend/tests/story_engine/test_story50_generate_panel.py
@@ -4,12 +4,13 @@ Story 50 test gate — POST /panel/{panel_id}/generate endpoint.
 Test invariants:
   1. First call (empty attributes): creates EditEvent(GENERATE_PANEL, SUCCEEDED),
      panel.attributes is populated, panel.source_event_id is set.
-  2. Second call (populated attributes): updates panel.attributes, creates a
-     new EditEvent(GENERATE_PANEL, SUCCEEDED), source_event_id updated.
-  3. input_snapshot on the EditEvent contains the attributes before the change.
+  2. Calling generate on a panel that already has content returns 400.
+  3. input_snapshot on the EditEvent is empty dict (first-gen has no prior attrs).
   4. output_snapshot contains the new attributes.
   5. Returns 404 for a panel that does not exist.
   6. EditEvent is marked FAILED (not left as PENDING) when the LLM call raises.
+  7. generate creates panel_character join rows for characters in the LLM response.
+  8. generate with a character slug not in the story does not create a join row for it.
 """
 
 import uuid
@@ -28,6 +29,7 @@ from core.story_engine.models.edit_event import (
     EditEventStatus,
     EditEventTargetType,
 )
+from core.story_engine.models.panel_character import PanelCharacter
 
 
 def _auth_headers(user_id: uuid.UUID) -> dict[str, str]:
@@ -153,7 +155,7 @@ async def test_generate_panel_first_call_sets_source_event_id(
     assert refreshed_panel.source_event_id is not None
 
 
-async def test_generate_panel_input_snapshot_contains_before_attributes(
+async def test_generate_panel_returns_400_if_already_generated(
     api_client: AsyncClient,
     db_session: AsyncSession,
     user: User,
@@ -161,13 +163,37 @@ async def test_generate_panel_input_snapshot_contains_before_attributes(
     story: Story,
     character: Character,
 ) -> None:
-    """input_snapshot on EditEvent captures attributes before the change."""
-    initial_attrs = {"background": "Forest", "dialogue": "Hello", "characters": []}
-    panel = Panel.create(story_id=story.id, order_index=0, attributes=initial_attrs)
+    """400 when panel already has content — caller should use /refine instead."""
+    panel = Panel.create(
+        story_id=story.id,
+        order_index=0,
+        attributes={"background": "Forest", "dialogue": "Hello", "characters": []},
+    )
     db_session.add(panel)
     await db_session.commit()
 
-    mock_content = _mock_panel_content(background="Mountain")
+    response = await api_client.post(
+        f"/api/comic-builder/v2/project/{project.id}/story/{story.id}"
+        f"/panel/{panel.id}/generate",
+        headers=_auth_headers(user.id),
+    )
+    assert response.status_code == 400
+
+
+async def test_generate_panel_input_snapshot_is_empty_on_first_gen(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+) -> None:
+    """input_snapshot is empty dict on first generation (no prior attributes)."""
+    panel = Panel.create(story_id=story.id, order_index=0, attributes={})
+    db_session.add(panel)
+    await db_session.commit()
+
+    mock_content = _mock_panel_content()
 
     with patch(
         "core.story_engine.service.panel_service.instructor_client.chat.completions.create",
@@ -177,7 +203,6 @@ async def test_generate_panel_input_snapshot_contains_before_attributes(
         await api_client.post(
             f"/api/comic-builder/v2/project/{project.id}/story/{story.id}"
             f"/panel/{panel.id}/generate",
-            json={"instruction": "Change location"},
             headers=_auth_headers(user.id),
         )
 
@@ -188,7 +213,7 @@ async def test_generate_panel_input_snapshot_contains_before_attributes(
         )
     )
     event = result.scalar_one()
-    assert event.input_snapshot == initial_attrs
+    assert event.input_snapshot == {}
 
 
 async def test_generate_panel_output_snapshot_contains_new_attributes(
@@ -279,3 +304,80 @@ async def test_generate_panel_edit_event_marked_failed_on_llm_error(
     event = result.scalar_one_or_none()
     assert event is not None
     assert event.status == EditEventStatus.FAILED
+
+
+async def test_generate_panel_creates_panel_character_join_rows(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+) -> None:
+    """generate creates panel_character rows for characters in the LLM response."""
+    panel = Panel.create(story_id=story.id, order_index=0, attributes={})
+    db_session.add(panel)
+    await db_session.commit()
+
+    # LLM returns the character's slug
+    mock_content = _mock_panel_content(characters=[character.slug])
+
+    with patch(
+        "core.story_engine.service.panel_service.instructor_client.chat.completions.create",
+        new_callable=AsyncMock,
+        return_value=mock_content,
+    ):
+        response = await api_client.post(
+            f"/api/comic-builder/v2/project/{project.id}/story/{story.id}"
+            f"/panel/{panel.id}/generate",
+            headers=_auth_headers(user.id),
+        )
+
+    assert response.status_code == 200
+
+    result = await db_session.execute(
+        select(PanelCharacter).where(PanelCharacter.panel_id == panel.id)
+    )
+    rows = list(result.scalars().all())
+    assert len(rows) == 1
+    assert rows[0].character_id == character.id
+
+
+async def test_generate_panel_skips_unknown_slug_in_join_rows(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    user: User,
+    project: Project,
+    story: Story,
+    character: Character,
+) -> None:
+    """generate skips panel_character creation for slugs not in the story."""
+    panel = Panel.create(story_id=story.id, order_index=0, attributes={})
+    db_session.add(panel)
+    await db_session.commit()
+
+    # LLM returns one valid slug and one that doesn't exist
+    mock_content = _mock_panel_content(
+        characters=[character.slug, "nonexistent-character"]
+    )
+
+    with patch(
+        "core.story_engine.service.panel_service.instructor_client.chat.completions.create",
+        new_callable=AsyncMock,
+        return_value=mock_content,
+    ):
+        response = await api_client.post(
+            f"/api/comic-builder/v2/project/{project.id}/story/{story.id}"
+            f"/panel/{panel.id}/generate",
+            headers=_auth_headers(user.id),
+        )
+
+    assert response.status_code == 200
+
+    result = await db_session.execute(
+        select(PanelCharacter).where(PanelCharacter.panel_id == panel.id)
+    )
+    rows = list(result.scalars().all())
+    # Only one row — the invalid slug was silently dropped
+    assert len(rows) == 1
+    assert rows[0].character_id == character.id

--- a/backend/tests/story_engine/test_story60_render_panel.py
+++ b/backend/tests/story_engine/test_story60_render_panel.py
@@ -94,7 +94,7 @@ async def test_render_panel_creates_image_row_with_panel_render_discriminator(
             return_value=_mock_fal_response(),
         ),
         patch(
-            "core.story_engine.service.panel_service.GCSUploadService.upload",
+            "core.story_engine.service.image_service.GCSUploadService.upload",
             return_value=mock_receipt,
         ),
         patch(
@@ -150,7 +150,7 @@ async def test_render_panel_creates_edit_event_render_panel_succeeded(
             return_value=_mock_fal_response(),
         ),
         patch(
-            "core.story_engine.service.panel_service.GCSUploadService.upload",
+            "core.story_engine.service.image_service.GCSUploadService.upload",
             return_value=mock_receipt,
         ),
         patch(
@@ -206,7 +206,7 @@ async def test_render_panel_output_snapshot_contains_image_id(
             return_value=_mock_fal_response(),
         ),
         patch(
-            "core.story_engine.service.panel_service.GCSUploadService.upload",
+            "core.story_engine.service.image_service.GCSUploadService.upload",
             return_value=mock_receipt,
         ),
         patch(
@@ -221,7 +221,7 @@ async def test_render_panel_output_snapshot_contains_image_id(
         )
 
     assert response.status_code == 200
-    image_id = response.json()["id"]
+    image_id = response.json()["canonicalRender"]["id"]
 
     result = await db_session.execute(
         select(EditEvent).where(
@@ -263,7 +263,7 @@ async def test_render_panel_twice_creates_two_image_rows(
                 return_value=_mock_fal_response(),
             ),
             patch(
-                "core.story_engine.service.panel_service.GCSUploadService.upload",
+                "core.story_engine.service.image_service.GCSUploadService.upload",
                 return_value=mock_receipt,
             ),
             patch(
@@ -375,7 +375,7 @@ async def test_render_panel_characters_without_render_skipped_gracefully(
             return_value=_mock_fal_response(),
         ),
         patch(
-            "core.story_engine.service.panel_service.GCSUploadService.upload",
+            "core.story_engine.service.image_service.GCSUploadService.upload",
             return_value=mock_receipt,
         ),
         patch(

--- a/frontend/src/features/scene-engine/shared/scene-engine.queries.ts
+++ b/frontend/src/features/scene-engine/shared/scene-engine.queries.ts
@@ -1,0 +1,14 @@
+import { httpClient } from "@/lib/httpClient";
+import { queryOptions } from "@tanstack/react-query";
+import { STORY_API_BASE } from "./scene-engine.constants";
+
+export const imageSignedUrlOptions = (imageId: string) =>
+  queryOptions({
+    queryKey: ["image", imageId, "signed-url"] as const,
+    queryFn: () =>
+      httpClient.get<{ url: string; expiresAt: string }>(
+        `${STORY_API_BASE}/image/${imageId}/signed-url`,
+      ),
+    enabled: !!imageId,
+    staleTime: 55 * 60 * 1000,
+  });

--- a/frontend/src/features/scene-engine/steps.ts
+++ b/frontend/src/features/scene-engine/steps.ts
@@ -3,13 +3,15 @@ import PlaceholderStep from "./steps/PlaceholderStep";
 import StoryStep from "./steps/story/StoryStep";
 import CharacterExtractionStep from "./steps/character/extraction/CharacterExtractionStep";
 import CharacterRenderingStep from "./steps/character/rendering/CharacterRenderingStep";
+import PanelExtractionStep from "./steps/panel/extraction/PanelExtractionStep";
+import PanelRenderingStep from "./steps/panel/rendering/PanelRenderingStep";
 
 export const SCENE_STEPS: StepDef[] = [
   { id: 1, label: "Story",                component: StoryStep },
   { id: 2, label: "Character Extraction", component: CharacterExtractionStep },
   { id: 3, label: "Character Rendering",  component: CharacterRenderingStep },
-  { id: 4, label: "Scene Extraction",     component: PlaceholderStep },
-  { id: 5, label: "Scene Rendering",      component: PlaceholderStep },
+  { id: 4, label: "Panel Extraction",     component: PanelExtractionStep },
+  { id: 5, label: "Panel Rendering",      component: PanelRenderingStep },
   { id: 6, label: "Review",               component: PlaceholderStep },
   { id: 7, label: "Export",               component: PlaceholderStep },
 ];

--- a/frontend/src/features/scene-engine/steps/character/character.queries.ts
+++ b/frontend/src/features/scene-engine/steps/character/character.queries.ts
@@ -18,14 +18,3 @@ export const charactersOptions = (projectId: string, storyId: string) =>
     enabled: !!projectId && !!storyId,
     staleTime: Infinity,
   });
-
-export const imageSignedUrlOptions = (imageId: string) =>
-  queryOptions({
-    queryKey: ["image", imageId, "signed-url"] as const,
-    queryFn: () =>
-      httpClient.get<{ url: string; expiresAt: string }>(
-        `${STORY_API_BASE}/image/${imageId}/signed-url`,
-      ),
-    enabled: !!imageId,
-    staleTime: 55 * 60 * 1000,
-  });

--- a/frontend/src/features/scene-engine/steps/character/extraction/components/RefImageTray.tsx
+++ b/frontend/src/features/scene-engine/steps/character/extraction/components/RefImageTray.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Skeleton } from "@scene-engine/components/Skeleton";
-import { imageSignedUrlOptions } from "../../character.queries";
+import { imageSignedUrlOptions } from "@scene-engine/shared/scene-engine.queries";
 import type { ImageRecord } from "@scene-engine/shared/scene-engine.types";
 
 function RefImageThumbnail({

--- a/frontend/src/features/scene-engine/steps/character/extraction/components/ReferenceImageViewer.tsx
+++ b/frontend/src/features/scene-engine/steps/character/extraction/components/ReferenceImageViewer.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { Skeleton } from "@scene-engine/components/Skeleton";
-import { imageSignedUrlOptions } from "../../character.queries";
+import { imageSignedUrlOptions } from "@scene-engine/shared/scene-engine.queries";
 import type { ImageRecord } from "@scene-engine/shared/scene-engine.types";
 
 type ReferenceImageViewerProps = {

--- a/frontend/src/features/scene-engine/steps/character/rendering/components/Carousel.tsx
+++ b/frontend/src/features/scene-engine/steps/character/rendering/components/Carousel.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Skeleton } from "@scene-engine/components/Skeleton";
-import { imageSignedUrlOptions } from "../../character.queries";
+import { imageSignedUrlOptions } from "@scene-engine/shared/scene-engine.queries";
 import type { ImageRecord } from "@scene-engine/shared/scene-engine.types";
 
 function CarouselImage({ render }: { render: ImageRecord }) {

--- a/frontend/src/features/scene-engine/steps/character/rendering/components/Carousel.tsx
+++ b/frontend/src/features/scene-engine/steps/character/rendering/components/Carousel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Skeleton } from "@scene-engine/components/Skeleton";
 import { imageSignedUrlOptions } from "@scene-engine/shared/scene-engine.queries";
@@ -30,17 +30,15 @@ function CarouselImage({ render }: { render: ImageRecord }) {
 
 type CarouselProps = {
   items: ImageRecord[];
-  onIndexChange?: (i: number) => void;
-  initialIndex?: number;
+  index: number;
+  onIndexChange: (i: number) => void;
 };
 
-export function Carousel({ items, onIndexChange, initialIndex }: CarouselProps) {
-  const [index, setIndex] = useState(initialIndex ?? 0);
+export function Carousel({ items, index, onIndexChange }: CarouselProps) {
   const touchStartX = useRef<number | null>(null);
 
   const setAndNotify = (i: number) => {
-    setIndex(i);
-    onIndexChange?.(i);
+    onIndexChange(i);
   };
 
   const prev = () => setAndNotify(Math.max(0, index - 1));

--- a/frontend/src/features/scene-engine/steps/character/rendering/components/CharacterRenderModal.tsx
+++ b/frontend/src/features/scene-engine/steps/character/rendering/components/CharacterRenderModal.tsx
@@ -50,6 +50,7 @@ export function CharacterRenderModal({ bundle, onDismiss }: CharacterRenderModal
     }
 
     editRender({ characterId, imageId: sourceImage.id, instruction, referenceImageId });
+    setSelectedIndex(0);
   };
 
   const headerActions = (
@@ -83,12 +84,11 @@ export function CharacterRenderModal({ bundle, onDismiss }: CharacterRenderModal
         </div>
       );
     }
-    const canonicalIndex = renders.findIndex((r: ImageRecord) => r.id === bundle.canonicalRender?.id);
     return (
       <Carousel
         items={renders}
+        index={selectedIndex}
         onIndexChange={setSelectedIndex}
-        initialIndex={canonicalIndex === -1 ? 0 : canonicalIndex}
       />
     );
   };

--- a/frontend/src/features/scene-engine/steps/character/rendering/components/CharacterRenderingList.tsx
+++ b/frontend/src/features/scene-engine/steps/character/rendering/components/CharacterRenderingList.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Skeleton } from "@scene-engine/components/Skeleton";
 import { useSceneEngine } from "@scene-engine/context";
-import { imageSignedUrlOptions } from "../../character.queries";
+import { imageSignedUrlOptions } from "@scene-engine/shared/scene-engine.queries";
 import type { CharacterBundle } from "../../character.types";
 import type { ImageRecord } from "@scene-engine/shared/scene-engine.types";
 import { useCharacterRendering } from "../hooks/useCharacterRendering";

--- a/frontend/src/features/scene-engine/steps/panel/extraction/PanelExtractionStep.tsx
+++ b/frontend/src/features/scene-engine/steps/panel/extraction/PanelExtractionStep.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import { StepLoadingSkeleton } from "@scene-engine/components/StepLoadingSkeleton";
+import { useSceneEngine } from "@scene-engine/context";
+import { usePanelExtraction } from "./hooks/usePanelExtraction";
+import { PanelList } from "./components/PanelList";
+import { PanelModal } from "./components/PanelModal";
+import { ReferenceImageViewer } from "./components/ReferenceImageViewer";
+
+function EmptyState({
+  onExtract,
+  isExtracting,
+  error,
+}: {
+  onExtract: () => void;
+  isExtracting: boolean;
+  error: string | null;
+}) {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <div className="w-full max-w-4xl">
+        <div className="flex items-center justify-between border border-border p-4">
+          <div className="flex flex-col gap-1">
+            <span className="text-xs font-medium">Extract Panels</span>
+            <span
+              className={`text-[10px] ${error ? "text-destructive" : "text-muted-foreground"}`}
+            >
+              {error ??
+                "Analyse your story and extract all panels with their scene descriptions."}
+            </span>
+          </div>
+          <button
+            onClick={onExtract}
+            disabled={isExtracting || !!error}
+            className="ml-6 shrink-0 bg-foreground px-3 py-1.5 text-[10px] text-background hover:bg-foreground/80 disabled:opacity-50"
+          >
+            {isExtracting ? "Extracting…" : "Extract"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function PanelExtractionStep() {
+  const { projectId, storyId } = useSceneEngine();
+  const {
+    panels, isLoading,
+    extractPanels, isExtracting, extractError,
+    deleteReferenceImage, isDeleting,
+  } = usePanelExtraction(projectId, storyId);
+
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [viewingImageId, setViewingImageId] = useState<string | null>(null);
+
+  const activeBundle = activeId
+    ? panels?.find((b) => b.panel.id === activeId)
+    : null;
+
+  const activeIndex = activeId
+    ? (panels?.findIndex((b) => b.panel.id === activeId) ?? -1) + 1
+    : 0;
+
+  const viewingImage = activeBundle && viewingImageId
+    ? activeBundle.referenceImages.find((r) => r.id === viewingImageId)
+    : null;
+
+  const handleDelete = () => {
+    if (!activeId || !viewingImageId) return;
+    deleteReferenceImage(
+      { panelId: activeId, imageId: viewingImageId },
+      { onSuccess: () => setViewingImageId(null) },
+    );
+  };
+
+  if (isLoading) {
+    return <StepLoadingSkeleton />;
+  }
+
+  return (
+    <div className="relative flex h-full w-full flex-col">
+      {activeBundle && (
+        <PanelModal
+          bundle={activeBundle}
+          displayIndex={activeIndex}
+          onDismiss={() => { setActiveId(null); setViewingImageId(null); }}
+          onImageClick={setViewingImageId}
+        />
+      )}
+      {viewingImage && (
+        <ReferenceImageViewer
+          img={viewingImage}
+          onBack={() => setViewingImageId(null)}
+          onDelete={handleDelete}
+          isDeleting={isDeleting}
+        />
+      )}
+      {panels && panels.length > 0 ? (
+        <PanelList panels={panels} onActivate={setActiveId} />
+      ) : (
+        <EmptyState
+          onExtract={extractPanels}
+          isExtracting={isExtracting}
+          error={extractError}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/scene-engine/steps/panel/extraction/components/PanelAttributes.tsx
+++ b/frontend/src/features/scene-engine/steps/panel/extraction/components/PanelAttributes.tsx
@@ -1,0 +1,36 @@
+import type { PanelRecord } from "../../panel.types";
+
+type PanelAttributesProps = {
+  panel: PanelRecord;
+};
+
+function formatKey(key: string): string {
+  return key.replace(/_/g, " ");
+}
+
+function formatValue(value: unknown): string {
+  if (Array.isArray(value)) return value.join(", ");
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+export function PanelAttributes({ panel }: PanelAttributesProps) {
+  const entries = Object.entries(panel.attributes).filter(
+    ([, v]) => v !== null && v !== undefined && v !== "",
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      {entries.map(([key, value]) => (
+        <div key={key} className="flex flex-col gap-0.5">
+          <span className="text-[10px] font-semibold uppercase tracking-wide text-foreground/60">
+            {formatKey(key)}
+          </span>
+          <span className="text-xs text-foreground">
+            {formatValue(value)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/scene-engine/steps/panel/extraction/components/PanelCard.tsx
+++ b/frontend/src/features/scene-engine/steps/panel/extraction/components/PanelCard.tsx
@@ -1,0 +1,23 @@
+import type { PanelBundle } from "../../panel.types";
+import { PanelAttributes } from "./PanelAttributes";
+import { RefImageTray } from "./RefImageTray";
+
+type PanelCardProps = {
+  bundle: PanelBundle;
+  displayIndex: number;
+  onActivate: () => void;
+};
+
+export function PanelCard({ bundle, displayIndex, onActivate }: PanelCardProps) {
+  return (
+    <div className="flex" onClick={onActivate}>
+      <div className="min-w-0 flex-1 cursor-pointer border border-border bg-muted/20 p-3 hover:bg-muted/40">
+        <span className="mb-2 block text-[10px] font-semibold uppercase tracking-wide text-foreground/60">
+          Panel {displayIndex}
+        </span>
+        <PanelAttributes panel={bundle.panel} />
+      </div>
+      <RefImageTray images={bundle.referenceImages} variant="card" />
+    </div>
+  );
+}

--- a/frontend/src/features/scene-engine/steps/panel/extraction/components/PanelList.tsx
+++ b/frontend/src/features/scene-engine/steps/panel/extraction/components/PanelList.tsx
@@ -1,0 +1,24 @@
+import type { PanelBundle } from "../../panel.types";
+import { PanelCard } from "./PanelCard";
+
+type PanelListProps = {
+  panels: PanelBundle[];
+  onActivate: (panelId: string) => void;
+};
+
+export function PanelList({ panels, onActivate }: PanelListProps) {
+  return (
+    <div className="h-full w-full overflow-y-auto p-4">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-2">
+        {panels.map((bundle, index) => (
+          <PanelCard
+            key={bundle.panel.id}
+            bundle={bundle}
+            displayIndex={index + 1}
+            onActivate={() => onActivate(bundle.panel.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/scene-engine/steps/panel/extraction/components/PanelModal.tsx
+++ b/frontend/src/features/scene-engine/steps/panel/extraction/components/PanelModal.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { ModalShell } from "@scene-engine/components/ModalShell";
+import PromptInput from "@scene-engine/components/PromptInput";
+import { ValidationErrorBlock } from "@scene-engine/components/ValidationErrorBlock";
+import { useSceneEngine } from "@scene-engine/context";
+import { useFilePicker } from "@scene-engine/hooks/useFilePicker";
+import type { PanelBundle } from "../../panel.types";
+import { usePanelExtraction } from "../hooks/usePanelExtraction";
+import { PanelAttributes } from "./PanelAttributes";
+import { RefImageTray } from "./RefImageTray";
+
+type PanelModalProps = {
+  bundle: PanelBundle;
+  displayIndex: number;
+  onDismiss: () => void;
+  onImageClick: (imageId: string) => void;
+};
+
+export function PanelModal({ bundle, displayIndex, onDismiss, onImageClick }: PanelModalProps) {
+  const { projectId, storyId } = useSceneEngine();
+  const { refinePanel, isRefining, uploadReferenceImage, isUploading } =
+    usePanelExtraction(projectId, storyId);
+
+  const panelId = bundle.panel.id;
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const { triggerPick, inputProps } = useFilePicker({
+    accept: "image/*",
+    multiple: false,
+    onPick: ([file]) => uploadReferenceImage({ panelId, file }),
+    onReject: setValidationError,
+  });
+
+  return (
+    <ModalShell header={`Panel ${displayIndex}`} onDismiss={onDismiss}>
+      <div className="flex min-h-0 flex-1">
+        <div className="min-h-0 flex-1 overflow-y-auto p-3">
+          <PanelAttributes panel={bundle.panel} />
+        </div>
+        <RefImageTray
+          images={bundle.referenceImages}
+          variant="modal"
+          onImageClick={onImageClick}
+        />
+      </div>
+      <div className="shrink-0">
+        {validationError && (
+          <ValidationErrorBlock
+            message={validationError}
+            onClear={() => setValidationError(null)}
+          />
+        )}
+        <div className="px-3 py-2">
+          <input {...inputProps} />
+          <button
+            onClick={triggerPick}
+            disabled={isUploading}
+            className="bg-foreground px-2 py-1 text-[10px] text-background hover:bg-foreground/80 disabled:opacity-50"
+          >
+            {isUploading ? "Uploading…" : "Upload a reference image"}
+          </button>
+        </div>
+      </div>
+      <div className="shrink-0 border-t border-border">
+        <PromptInput
+          onSend={(instruction) => refinePanel({ panelId, instruction })}
+          placeholder="Refine this panel…"
+          disabled={isRefining}
+          enableVoiceTranscription
+        />
+      </div>
+    </ModalShell>
+  );
+}

--- a/frontend/src/features/scene-engine/steps/panel/extraction/components/RefImageTray.tsx
+++ b/frontend/src/features/scene-engine/steps/panel/extraction/components/RefImageTray.tsx
@@ -1,0 +1,67 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Skeleton } from "@scene-engine/components/Skeleton";
+import { imageSignedUrlOptions } from "@scene-engine/shared/scene-engine.queries";
+import type { ImageRecord } from "@scene-engine/shared/scene-engine.types";
+
+function RefImageThumbnail({
+  img,
+  isLast,
+  onClick,
+}: {
+  img: ImageRecord;
+  isLast: boolean;
+  onClick?: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const { data } = useQuery(imageSignedUrlOptions(img.id));
+
+  return (
+    <div
+      onClick={onClick}
+      className={`relative aspect-square w-full shrink-0 cursor-pointer bg-muted/20 hover:bg-muted/40 ${
+        !isLast ? "border-b border-border" : ""
+      }`}
+    >
+      {data?.url ? (
+        <img
+          src={data.url}
+          alt=""
+          className="h-full w-full object-cover"
+          onError={() =>
+            void queryClient.invalidateQueries({
+              queryKey: imageSignedUrlOptions(img.id).queryKey,
+            })
+          }
+        />
+      ) : (
+        <Skeleton className="h-full w-full" />
+      )}
+    </div>
+  );
+}
+
+type RefImageTrayProps = {
+  images: ImageRecord[];
+  variant: "card" | "modal";
+  onImageClick?: (imageId: string) => void;
+};
+
+export function RefImageTray({ images, variant, onImageClick }: RefImageTrayProps) {
+  const outerClass =
+    variant === "card"
+      ? `border border-l-0 ${images.length > 0 ? "border-border" : "border-transparent"}`
+      : "";
+
+  return (
+    <div className={`flex w-16 shrink-0 self-end flex-col overflow-y-auto ${outerClass}`}>
+      {images.map((img, i) => (
+        <RefImageThumbnail
+          key={img.id}
+          img={img}
+          isLast={i === images.length - 1}
+          onClick={onImageClick ? () => onImageClick(img.id) : undefined}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/scene-engine/steps/panel/extraction/components/ReferenceImageViewer.tsx
+++ b/frontend/src/features/scene-engine/steps/panel/extraction/components/ReferenceImageViewer.tsx
@@ -1,0 +1,55 @@
+import { useQuery } from "@tanstack/react-query";
+import { Skeleton } from "@scene-engine/components/Skeleton";
+import { imageSignedUrlOptions } from "@scene-engine/shared/scene-engine.queries";
+import type { ImageRecord } from "@scene-engine/shared/scene-engine.types";
+
+type ReferenceImageViewerProps = {
+  img: ImageRecord;
+  onBack: () => void;
+  onDelete: () => void;
+  isDeleting: boolean;
+};
+
+export function ReferenceImageViewer({
+  img,
+  onBack,
+  onDelete,
+  isDeleting,
+}: ReferenceImageViewerProps) {
+  const { data } = useQuery(imageSignedUrlOptions(img.id));
+
+  return (
+    <div className="absolute inset-0 z-30 flex flex-col border border-border bg-background">
+      <div className="flex shrink-0 items-center justify-between border-b border-border px-3 py-2">
+        <span className="text-[10px] text-muted-foreground">{img.id}</span>
+        <div className="flex gap-2">
+          <button
+            onClick={onDelete}
+            disabled={isDeleting}
+            className="border border-border px-2 py-1 text-[10px] text-muted-foreground hover:bg-muted/40 disabled:opacity-50"
+          >
+            {isDeleting ? "Deleting…" : "Delete"}
+          </button>
+          <button
+            onClick={onBack}
+            className="bg-foreground px-2 py-1 text-[10px] text-background hover:bg-foreground/80"
+          >
+            ← Back
+          </button>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1 items-center justify-center bg-muted/10 p-4">
+        {data?.url ? (
+          <img
+            src={data.url}
+            alt=""
+            className="max-h-full max-w-full object-contain"
+          />
+        ) : (
+          <Skeleton className="h-full w-full" />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/scene-engine/steps/panel/extraction/hooks/usePanelExtraction.ts
+++ b/frontend/src/features/scene-engine/steps/panel/extraction/hooks/usePanelExtraction.ts
@@ -1,0 +1,102 @@
+import { httpClient } from "@/lib/httpClient";
+import { STORY_API_BASE } from "@scene-engine/shared/scene-engine.constants";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { panelsOptions } from "../../panel.queries";
+import { splicePanelIntoList, uploadReferenceImageRequest, buildHttpErrorMessage } from "../../panel.utils";
+import type { PanelBundle } from "../../panel.types";
+
+export function usePanelExtraction(projectId: string, storyId: string) {
+  const queryClient = useQueryClient();
+  const queryKey = panelsOptions(projectId, storyId).queryKey;
+
+  const { data: panels, isLoading } = useQuery(
+    panelsOptions(projectId, storyId),
+  );
+
+  const {
+    mutate: extractPanels,
+    isPending: isExtracting,
+    error: rawExtractError,
+  } = useMutation({
+    mutationFn: () =>
+      httpClient.post<PanelBundle[]>(
+        `${STORY_API_BASE}/project/${projectId}/story/${storyId}/panels/generate`,
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  const { mutate: refinePanel, isPending: isRefining } = useMutation({
+    mutationFn: ({
+      panelId,
+      instruction,
+    }: {
+      panelId: string;
+      instruction: string;
+    }) =>
+      httpClient.post<PanelBundle>(
+        `${STORY_API_BASE}/project/${projectId}/story/${storyId}/panel/${panelId}/refine`,
+        { instruction },
+      ),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(queryKey, (prev: PanelBundle[] | undefined) =>
+        prev ? splicePanelIntoList(prev, updated) : [updated],
+      );
+    },
+  });
+
+  const { mutate: uploadReferenceImage, isPending: isUploading } = useMutation({
+    mutationFn: ({ panelId, file }: { panelId: string; file: File }) =>
+      uploadReferenceImageRequest(projectId, storyId, panelId, file),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(queryKey, (prev: PanelBundle[] | undefined) =>
+        prev ? splicePanelIntoList(prev, updated) : [updated],
+      );
+    },
+  });
+
+  const { mutate: deleteReferenceImage, isPending: isDeleting } = useMutation({
+    mutationFn: ({
+      panelId,
+      imageId,
+    }: {
+      panelId: string;
+      imageId: string;
+    }) =>
+      httpClient.delete(
+        `${STORY_API_BASE}/project/${projectId}/story/${storyId}/panel/${panelId}/reference-image/${imageId}`,
+      ),
+    onSuccess: (_, { panelId, imageId }) => {
+      queryClient.setQueryData(queryKey, (prev: PanelBundle[] | undefined) =>
+        prev?.map((b) =>
+          b.panel.id === panelId
+            ? {
+                ...b,
+                referenceImages: b.referenceImages.filter((r) => r.id !== imageId),
+              }
+            : b,
+        ),
+      );
+    },
+  });
+
+  return {
+    panels,
+    isLoading,
+    extractPanels,
+    isExtracting,
+    extractError: rawExtractError
+      ? buildHttpErrorMessage(rawExtractError, {
+          400: "Your story has no text yet. Go to Step 1 and write a story first.",
+          422: "Extract characters first — panels require characters to exist.",
+        }, "Something went wrong. Try again.")
+      : null,
+    refinePanel,
+    isRefining,
+    uploadReferenceImage,
+    isUploading,
+    deleteReferenceImage,
+    isDeleting,
+  };
+}

--- a/frontend/src/features/scene-engine/steps/panel/panel.queries.ts
+++ b/frontend/src/features/scene-engine/steps/panel/panel.queries.ts
@@ -1,0 +1,20 @@
+import { httpClient } from "@/lib/httpClient";
+import { queryOptions } from "@tanstack/react-query";
+import { STORY_API_BASE, STORY_QUERY_ROOT } from "@scene-engine/shared/scene-engine.constants";
+import type { PanelBundle } from "./panel.types";
+
+export const panelsOptions = (projectId: string, storyId: string) =>
+  queryOptions({
+    queryKey: [
+      ...STORY_QUERY_ROOT,
+      "project", projectId,
+      "story", storyId,
+      "panels",
+    ] as const,
+    queryFn: () =>
+      httpClient.get<PanelBundle[]>(
+        `${STORY_API_BASE}/project/${projectId}/story/${storyId}/panels`,
+      ),
+    enabled: !!projectId && !!storyId,
+    staleTime: Infinity,
+  });

--- a/frontend/src/features/scene-engine/steps/panel/panel.types.ts
+++ b/frontend/src/features/scene-engine/steps/panel/panel.types.ts
@@ -1,0 +1,17 @@
+import type { ImageRecord } from "@scene-engine/shared/scene-engine.types";
+
+export type PanelRecord = {
+  id: string;
+  storyId: string;
+  sourceEventId: string | null;
+  orderIndex: number;
+  attributes: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PanelBundle = {
+  panel: PanelRecord;
+  canonicalRender: ImageRecord | null;
+  referenceImages: ImageRecord[];
+};

--- a/frontend/src/features/scene-engine/steps/panel/panel.utils.ts
+++ b/frontend/src/features/scene-engine/steps/panel/panel.utils.ts
@@ -1,0 +1,39 @@
+import { isAxiosError } from "axios";
+import { httpClient } from "@/lib/httpClient";
+import { STORY_API_BASE } from "@scene-engine/shared/scene-engine.constants";
+import type { PanelBundle } from "./panel.types";
+
+export function splicePanelIntoList(
+  list: PanelBundle[],
+  updated: PanelBundle,
+): PanelBundle[] {
+  return list.map((b) =>
+    b.panel.id === updated.panel.id ? updated : b,
+  );
+}
+
+export function buildHttpErrorMessage(
+  error: unknown,
+  statusMessages: Record<number, string>,
+  fallback: string,
+): string {
+  if (isAxiosError(error)) {
+    const status = error.response?.status;
+    if (status && statusMessages[status]) return statusMessages[status];
+  }
+  return fallback;
+}
+
+export async function uploadReferenceImageRequest(
+  projectId: string,
+  storyId: string,
+  panelId: string,
+  file: File,
+): Promise<PanelBundle> {
+  const formData = new FormData();
+  formData.append("image", file);
+  return httpClient.post<PanelBundle>(
+    `${STORY_API_BASE}/project/${projectId}/story/${storyId}/panel/${panelId}/upload-reference-image`,
+    formData,
+  );
+}

--- a/frontend/src/features/scene-engine/steps/panel/rendering/PanelRenderingStep.tsx
+++ b/frontend/src/features/scene-engine/steps/panel/rendering/PanelRenderingStep.tsx
@@ -1,0 +1,48 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { StepLoadingSkeleton } from "@scene-engine/components/StepLoadingSkeleton";
+import { useSceneEngine } from "@scene-engine/context";
+import { panelsOptions } from "../panel.queries";
+import { PanelRenderModal } from "./components/PanelRenderModal";
+import { PanelRenderingList } from "./components/PanelRenderingList";
+import { NoPanelsState } from "./components/EmptyState";
+
+export default function PanelRenderingStep() {
+  const { projectId, storyId } = useSceneEngine();
+  const { data: panels, isLoading } = useQuery(
+    panelsOptions(projectId, storyId),
+  );
+
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const activeBundle = activeId
+    ? panels?.find((b) => b.panel.id === activeId)
+    : null;
+
+  const activeIndex = activeId
+    ? (panels?.findIndex((b) => b.panel.id === activeId) ?? -1) + 1
+    : 0;
+
+  if (isLoading) {
+    return <StepLoadingSkeleton />;
+  }
+
+  return (
+    <div className="relative flex h-full w-full flex-col">
+      {activeBundle && (
+        <PanelRenderModal
+          bundle={activeBundle}
+          displayIndex={activeIndex}
+          onDismiss={() => setActiveId(null)}
+        />
+      )}
+      {panels && panels.length > 0 ? (
+        <PanelRenderingList
+          panels={panels}
+          onActivate={setActiveId}
+        />
+      ) : (
+        <NoPanelsState />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/scene-engine/steps/panel/rendering/components/Carousel.tsx
+++ b/frontend/src/features/scene-engine/steps/panel/rendering/components/Carousel.tsx
@@ -1,0 +1,107 @@
+import { useRef, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Skeleton } from "@scene-engine/components/Skeleton";
+import { imageSignedUrlOptions } from "@scene-engine/shared/scene-engine.queries";
+import type { ImageRecord } from "@scene-engine/shared/scene-engine.types";
+
+function CarouselImage({ render }: { render: ImageRecord }) {
+  const queryClient = useQueryClient();
+  const { data } = useQuery(imageSignedUrlOptions(render.id));
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center">
+      {data?.url ? (
+        <img
+          src={data.url}
+          alt=""
+          className="h-full w-full object-contain"
+          onError={() =>
+            void queryClient.invalidateQueries({
+              queryKey: imageSignedUrlOptions(render.id).queryKey,
+            })
+          }
+        />
+      ) : (
+        <Skeleton className="h-full w-full" />
+      )}
+    </div>
+  );
+}
+
+type CarouselProps = {
+  items: ImageRecord[];
+  onIndexChange?: (i: number) => void;
+  initialIndex?: number;
+};
+
+export function Carousel({ items, onIndexChange, initialIndex }: CarouselProps) {
+  const [index, setIndex] = useState(initialIndex ?? 0);
+  const touchStartX = useRef<number | null>(null);
+
+  const setAndNotify = (i: number) => {
+    setIndex(i);
+    onIndexChange?.(i);
+  };
+
+  const prev = () => setAndNotify(Math.max(0, index - 1));
+  const next = () => setAndNotify(Math.min(items.length - 1, index + 1));
+
+  const hasPrev = index > 0;
+  const hasNext = index < items.length - 1;
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+    const diff = touchStartX.current - e.changedTouches[0].clientX;
+    if (diff > 40) next();
+    else if (diff < -40) prev();
+    touchStartX.current = null;
+  };
+
+  const current = items[index];
+
+  return (
+    <div
+      className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-muted/20"
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      {current && <CarouselImage render={current} />}
+
+      {hasPrev && (
+        <button
+          onClick={prev}
+          className="absolute left-2 top-1/2 -translate-y-1/2 bg-background px-2 py-1 text-xl text-foreground opacity-50 hover:opacity-100"
+        >
+          ‹
+        </button>
+      )}
+
+      {hasNext && (
+        <button
+          onClick={next}
+          className="absolute right-2 top-1/2 -translate-y-1/2 bg-background px-2 py-1 text-xl text-foreground opacity-50 hover:opacity-100"
+        >
+          ›
+        </button>
+      )}
+
+      {items.length > 1 && (
+        <div className="absolute bottom-3 flex gap-1.5">
+          {items.map((_, i) => (
+            <div
+              key={i}
+              onClick={() => setAndNotify(i)}
+              className={`h-1.5 w-1.5 cursor-pointer transition-colors ${
+                i === index ? "bg-foreground" : "bg-border"
+              }`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/scene-engine/steps/panel/rendering/components/Carousel.tsx
+++ b/frontend/src/features/scene-engine/steps/panel/rendering/components/Carousel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Skeleton } from "@scene-engine/components/Skeleton";
 import { imageSignedUrlOptions } from "@scene-engine/shared/scene-engine.queries";
@@ -30,17 +30,15 @@ function CarouselImage({ render }: { render: ImageRecord }) {
 
 type CarouselProps = {
   items: ImageRecord[];
-  onIndexChange?: (i: number) => void;
-  initialIndex?: number;
+  index: number;
+  onIndexChange: (i: number) => void;
 };
 
-export function Carousel({ items, onIndexChange, initialIndex }: CarouselProps) {
-  const [index, setIndex] = useState(initialIndex ?? 0);
+export function Carousel({ items, index, onIndexChange }: CarouselProps) {
   const touchStartX = useRef<number | null>(null);
 
   const setAndNotify = (i: number) => {
-    setIndex(i);
-    onIndexChange?.(i);
+    onIndexChange(i);
   };
 
   const prev = () => setAndNotify(Math.max(0, index - 1));

--- a/frontend/src/features/scene-engine/steps/panel/rendering/components/EmptyState.tsx
+++ b/frontend/src/features/scene-engine/steps/panel/rendering/components/EmptyState.tsx
@@ -1,0 +1,13 @@
+export function NoPanelsState() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <div className="w-full max-w-4xl">
+        <div className="flex items-center border border-border p-4">
+          <span className="text-[10px] text-muted-foreground">
+            Complete Panel Extraction first to enable this step.
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/scene-engine/steps/panel/rendering/components/PanelRenderModal.tsx
+++ b/frontend/src/features/scene-engine/steps/panel/rendering/components/PanelRenderModal.tsx
@@ -51,6 +51,7 @@ export function PanelRenderModal({ bundle, displayIndex, onDismiss }: PanelRende
     }
 
     editRender({ panelId, imageId: sourceImage.id, instruction, referenceImageId });
+    setSelectedIndex(0);
   };
 
   const headerActions = (
@@ -84,12 +85,11 @@ export function PanelRenderModal({ bundle, displayIndex, onDismiss }: PanelRende
         </div>
       );
     }
-    const canonicalIndex = renders.findIndex((r: ImageRecord) => r.id === bundle.canonicalRender?.id);
     return (
       <Carousel
         items={renders}
+        index={selectedIndex}
         onIndexChange={setSelectedIndex}
-        initialIndex={canonicalIndex === -1 ? 0 : canonicalIndex}
       />
     );
   };

--- a/frontend/src/features/scene-engine/steps/panel/rendering/components/PanelRenderModal.tsx
+++ b/frontend/src/features/scene-engine/steps/panel/rendering/components/PanelRenderModal.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ModalShell } from "@scene-engine/components/ModalShell";
+import PromptInput from "@scene-engine/components/PromptInput";
+import { Skeleton } from "@scene-engine/components/Skeleton";
+import { useSceneEngine } from "@scene-engine/context";
+import type { PanelBundle } from "../../panel.types";
+import type { ImageRecord } from "@scene-engine/shared/scene-engine.types";
+import { panelRendersOptions } from "../rendering.queries";
+import { usePanelRendering } from "../hooks/usePanelRendering";
+import { Carousel } from "./Carousel";
+
+type PanelRenderModalProps = {
+  bundle: PanelBundle;
+  displayIndex: number;
+  onDismiss: () => void;
+};
+
+export function PanelRenderModal({ bundle, displayIndex, onDismiss }: PanelRenderModalProps) {
+  const { projectId, storyId } = useSceneEngine();
+  const panelId = bundle.panel.id;
+
+  const { uploadReferenceImage, editRender, editingIds, setCanonicalRender, isSettingCanonical } = usePanelRendering(projectId, storyId);
+  const isEditing = editingIds.has(panelId);
+
+  const { data: renders, isLoading } = useQuery(
+    panelRendersOptions(projectId, storyId, panelId),
+  );
+
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useEffect(() => {
+    if (!renders) return;
+    const idx = renders.findIndex((r: ImageRecord) => r.id === bundle.canonicalRender?.id);
+    setSelectedIndex(idx === -1 ? 0 : idx);
+  }, [renders, bundle.canonicalRender?.id]);
+
+  const selectedRender = renders?.[selectedIndex];
+  const isCanonical = !!selectedRender && selectedRender.id === bundle.canonicalRender?.id;
+
+  const handleSend = async (instruction: string, files: File[]) => {
+    if (!renders || renders.length === 0) return;
+    const sourceImage = renders[selectedIndex];
+    if (!sourceImage) return;
+
+    let referenceImageId: string | undefined;
+
+    if (files.length > 0) {
+      const updatedBundle = await uploadReferenceImage({ panelId, file: files[0] });
+      referenceImageId = updatedBundle.referenceImages.at(-1)?.id;
+    }
+
+    editRender({ panelId, imageId: sourceImage.id, instruction, referenceImageId });
+  };
+
+  const headerActions = (
+    <button
+      onClick={() => {
+        if (!selectedRender || isCanonical) return;
+        setCanonicalRender({ panelId, imageId: selectedRender.id });
+      }}
+      disabled={isCanonical || isSettingCanonical || !selectedRender}
+      className={`px-2 py-1 text-[10px] ${
+        isCanonical
+          ? "bg-foreground text-background"
+          : "border border-foreground/30 text-foreground hover:bg-muted/40 disabled:opacity-50"
+      }`}
+    >
+      {isSettingCanonical ? "Setting…" : isCanonical ? "✓ Selected" : "Use this"}
+    </button>
+  );
+
+  const renderBody = () => {
+    if (isLoading) {
+      return <Skeleton className="min-h-0 flex-1 w-full" />;
+    }
+    if (isEditing) {
+      return <Skeleton className="min-h-0 flex-1 w-full" label="Editing" showTimer />;
+    }
+    if (!renders || renders.length === 0) {
+      return (
+        <div className="flex min-h-0 flex-1 items-center justify-center bg-muted/20">
+          <span className="text-xs text-muted-foreground">No renders yet</span>
+        </div>
+      );
+    }
+    const canonicalIndex = renders.findIndex((r: ImageRecord) => r.id === bundle.canonicalRender?.id);
+    return (
+      <Carousel
+        items={renders}
+        onIndexChange={setSelectedIndex}
+        initialIndex={canonicalIndex === -1 ? 0 : canonicalIndex}
+      />
+    );
+  };
+
+  return (
+    <ModalShell
+      header={`Panel ${displayIndex}`}
+      onDismiss={onDismiss}
+      headerActions={headerActions}
+    >
+      {renderBody()}
+      <div className="shrink-0 border-t border-border">
+        <PromptInput
+          onSend={handleSend}
+          placeholder={isCanonical ? "Describe an edit…" : "Only the canonical render can be edited"}
+          disabled={isEditing || isLoading || !renders || renders.length === 0 || !isCanonical}
+          enableUploads
+          maxFiles={1}
+          acceptedFileTypes="image/*"
+          maxFileSizeMb={5}
+          enableVoiceTranscription
+        />
+      </div>
+    </ModalShell>
+  );
+}

--- a/frontend/src/features/scene-engine/steps/panel/rendering/components/PanelRenderingList.tsx
+++ b/frontend/src/features/scene-engine/steps/panel/rendering/components/PanelRenderingList.tsx
@@ -1,0 +1,116 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Skeleton } from "@scene-engine/components/Skeleton";
+import { useSceneEngine } from "@scene-engine/context";
+import { imageSignedUrlOptions } from "@scene-engine/shared/scene-engine.queries";
+import type { PanelBundle } from "../../panel.types";
+import type { ImageRecord } from "@scene-engine/shared/scene-engine.types";
+import { usePanelRendering } from "../hooks/usePanelRendering";
+
+type PanelRenderBlockProps = {
+  bundle: PanelBundle;
+  displayIndex: number;
+  onActivate: () => void;
+  onRender: () => void;
+  isRendering: boolean;
+  errorMessage: string | null;
+};
+
+function RenderedImage({ render }: { render: ImageRecord }) {
+  const queryClient = useQueryClient();
+  const { data } = useQuery(imageSignedUrlOptions(render.id));
+
+  return (
+    <div className="absolute inset-0">
+      {data?.url ? (
+        <img
+          src={data.url}
+          alt=""
+          className="h-full w-full object-contain"
+          onError={() =>
+            void queryClient.invalidateQueries({
+              queryKey: imageSignedUrlOptions(render.id).queryKey,
+            })
+          }
+        />
+      ) : (
+        <Skeleton className="h-full w-full" />
+      )}
+    </div>
+  );
+}
+
+function PanelRenderBlock({ bundle, displayIndex, onActivate, onRender, isRendering, errorMessage }: PanelRenderBlockProps) {
+  const hasRender = bundle.canonicalRender !== null;
+
+  return (
+    <div
+      className={bundle.canonicalRender ? "aspect-square w-full max-w-lg shrink-0" : "h-48 w-full max-w-lg shrink-0"}
+      onClick={onActivate}
+    >
+      <div className="relative flex h-full w-full cursor-pointer items-center justify-center border border-border bg-muted/20 hover:bg-muted/40">
+        {isRendering ? (
+          <>
+            <Skeleton className="absolute inset-0" />
+            <span className="relative text-xs text-muted-foreground">Rendering…</span>
+          </>
+        ) : (
+          <>
+            {hasRender && <RenderedImage render={bundle.canonicalRender!} />}
+            {!hasRender && (
+              <span className="text-xs text-muted-foreground">
+                Panel {displayIndex}
+              </span>
+            )}
+            {hasRender && (
+              <span className="absolute bottom-3 left-3 bg-background px-2 py-1 text-xs text-foreground">
+                Panel {displayIndex}
+              </span>
+            )}
+            <div className="absolute bottom-3 right-3 flex items-center gap-2">
+              {errorMessage && (
+                <span className="bg-background px-2 py-1 text-[10px] text-destructive">
+                  {errorMessage}
+                </span>
+              )}
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (hasRender) { onActivate(); } else { onRender(); }
+                }}
+                className="bg-foreground px-3 py-1.5 text-[10px] text-background hover:bg-foreground/80"
+              >
+                {hasRender ? "Edit" : "Render"}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+type PanelRenderingListProps = {
+  panels: PanelBundle[];
+  onActivate: (panelId: string) => void;
+};
+
+export function PanelRenderingList({ panels, onActivate }: PanelRenderingListProps) {
+  const { projectId, storyId } = useSceneEngine();
+  const { triggerRender, renderingIds, errorIds } = usePanelRendering(projectId, storyId);
+
+  return (
+    <div className="flex h-full w-full flex-col items-center gap-2 overflow-y-auto p-4">
+      {panels.map((bundle, index) => (
+        <PanelRenderBlock
+          key={bundle.panel.id}
+          bundle={bundle}
+          displayIndex={index + 1}
+          onActivate={() => onActivate(bundle.panel.id)}
+          onRender={() => triggerRender({ panelId: bundle.panel.id })}
+          isRendering={renderingIds.has(bundle.panel.id)}
+          errorMessage={errorIds.get(bundle.panel.id) ?? null}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/scene-engine/steps/panel/rendering/hooks/usePanelRendering.ts
+++ b/frontend/src/features/scene-engine/steps/panel/rendering/hooks/usePanelRendering.ts
@@ -1,0 +1,139 @@
+import { httpClient } from "@/lib/httpClient";
+import { STORY_API_BASE } from "@scene-engine/shared/scene-engine.constants";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { panelsOptions } from "../../panel.queries";
+import { splicePanelIntoList, uploadReferenceImageRequest, buildHttpErrorMessage } from "../../panel.utils";
+import type { PanelBundle } from "../../panel.types";
+import type { ImageRecord } from "@scene-engine/shared/scene-engine.types";
+import { panelRendersOptions } from "../rendering.queries";
+
+export function usePanelRendering(projectId: string, storyId: string) {
+  const queryClient = useQueryClient();
+  const panelsQueryKey = panelsOptions(projectId, storyId).queryKey;
+
+  const [renderingIds, setRenderingIds] = useState<Set<string>>(new Set());
+  const [editingIds, setEditingIds] = useState<Set<string>>(new Set());
+  const [errorIds, setErrorIds] = useState<Map<string, string>>(new Map());
+
+  const { mutate: triggerRender } = useMutation({
+    mutationFn: ({ panelId }: { panelId: string }) =>
+      httpClient.post<PanelBundle>(
+        `${STORY_API_BASE}/project/${projectId}/story/${storyId}/panel/${panelId}/render`,
+      ),
+    onMutate: ({ panelId }) => {
+      setRenderingIds((prev) => new Set(prev).add(panelId));
+      setErrorIds((prev) => {
+        const next = new Map(prev);
+        next.delete(panelId);
+        return next;
+      });
+    },
+    onSettled: (_, __, { panelId }) => {
+      setRenderingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(panelId);
+        return next;
+      });
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData(
+        panelsQueryKey,
+        (prev: PanelBundle[] | undefined) =>
+          prev ? splicePanelIntoList(prev, updated) : [updated],
+      );
+    },
+    onError: (error, { panelId }) => {
+      setErrorIds((prev) => {
+        const next = new Map(prev);
+        next.set(panelId, buildHttpErrorMessage(error, {
+          401: "Session expired. Please sign in again.",
+          404: "Panel not found. Try refreshing.",
+        }, "Render failed. Try again."));
+        return next;
+      });
+    },
+  });
+
+  const { mutateAsync: uploadReferenceImage, isPending: isUploading } = useMutation({
+    mutationFn: ({ panelId, file }: { panelId: string; file: File }) =>
+      uploadReferenceImageRequest(projectId, storyId, panelId, file),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(panelsQueryKey, (prev: PanelBundle[] | undefined) =>
+        prev ? splicePanelIntoList(prev, updated) : [updated],
+      );
+    },
+  });
+
+  const { mutate: editRender } = useMutation({
+    mutationFn: ({
+      panelId,
+      imageId,
+      instruction,
+      referenceImageId,
+    }: {
+      panelId: string;
+      imageId: string;
+      instruction: string;
+      referenceImageId?: string;
+    }) =>
+      httpClient.post<ImageRecord>(
+        `${STORY_API_BASE}/project/${projectId}/story/${storyId}/panel/${panelId}/render/edit`,
+        {
+          instruction,
+          sourceImageId: imageId,
+          ...(referenceImageId ? { referenceImageId } : {}),
+        },
+      ),
+    onMutate: ({ panelId }) => {
+      setEditingIds((prev) => new Set(prev).add(panelId));
+      setErrorIds((prev) => {
+        const next = new Map(prev);
+        next.delete(panelId);
+        return next;
+      });
+    },
+    onSettled: (_, __, { panelId }) => {
+      setEditingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(panelId);
+        return next;
+      });
+    },
+    onSuccess: (newRender, { panelId }) => {
+      queryClient.setQueryData(
+        panelRendersOptions(projectId, storyId, panelId).queryKey,
+        (prev: ImageRecord[] | undefined) =>
+          prev ? [newRender, ...prev] : [newRender],
+      );
+      void queryClient.invalidateQueries({ queryKey: panelsQueryKey });
+    },
+    onError: (error, { panelId }) => {
+      setErrorIds((prev) => {
+        const next = new Map(prev);
+        next.set(panelId, buildHttpErrorMessage(error, {
+          401: "Session expired. Please sign in again.",
+          404: "Panel not found. Try refreshing.",
+        }, "Render failed. Try again."));
+        return next;
+      });
+    },
+  });
+
+  const { mutate: setCanonicalRender, isPending: isSettingCanonical } = useMutation({
+    mutationFn: ({ panelId, imageId }: { panelId: string; imageId: string }) =>
+      httpClient.post<PanelBundle>(
+        `${STORY_API_BASE}/project/${projectId}/story/${storyId}/panel/${panelId}/set-canonical-render`,
+        { imageId },
+      ),
+    onSuccess: (updatedBundle) => {
+      queryClient.setQueryData(
+        panelsQueryKey,
+        (prev: PanelBundle[] | undefined) =>
+          prev ? splicePanelIntoList(prev, updatedBundle) : [updatedBundle],
+      );
+    },
+  });
+
+  return { triggerRender, renderingIds, uploadReferenceImage, isUploading, editRender, editingIds, setCanonicalRender, isSettingCanonical, errorIds };
+}

--- a/frontend/src/features/scene-engine/steps/panel/rendering/rendering.queries.ts
+++ b/frontend/src/features/scene-engine/steps/panel/rendering/rendering.queries.ts
@@ -1,0 +1,24 @@
+import { httpClient } from "@/lib/httpClient";
+import { queryOptions } from "@tanstack/react-query";
+import { STORY_API_BASE, STORY_QUERY_ROOT } from "@scene-engine/shared/scene-engine.constants";
+import type { ImageRecord } from "@scene-engine/shared/scene-engine.types";
+
+export const panelRendersOptions = (
+  projectId: string,
+  storyId: string,
+  panelId: string,
+) =>
+  queryOptions({
+    queryKey: [
+      ...STORY_QUERY_ROOT,
+      "project", projectId,
+      "story", storyId,
+      "panel", panelId,
+      "renders",
+    ] as const,
+    queryFn: () =>
+      httpClient.get<ImageRecord[]>(
+        `${STORY_API_BASE}/project/${projectId}/story/${storyId}/panel/${panelId}/renders`,
+      ),
+    enabled: !!projectId && !!storyId && !!panelId,
+  });


### PR DESCRIPTION
## Summary

Implements Steps 4 and 5 of the comic builder — Panel Extraction and Panel Rendering — as a full symmetric counterpart to the existing Character steps (PR #18).

## What's in this PR

### Refactor
- **Promotes `imageSignedUrlOptions` to `scene-engine/shared/scene-engine.queries.ts`** — previously lived in `character.queries.ts`, now shared across both character and panel domains. All 4 existing character import sites updated.

### New: Panel domain foundation
- `panel.types.ts` — `PanelRecord` and `PanelBundle` types
- `panel.queries.ts` — `panelsOptions` query (GET `/panels`)
- `panel.utils.ts` — `splicePanelIntoList`, `buildHttpErrorMessage`, `uploadReferenceImageRequest`

### New: Panel Extraction (Step 4)
- `usePanelExtraction` hook — bulk extract (`POST /panels/generate`), refine (`POST /panel/{id}/refine`), upload/delete reference images
- `PanelAttributes`, `PanelCard`, `PanelList`, `PanelModal`, `ReferenceImageViewer`, `RefImageTray` components
- `PanelExtractionStep` — empty state with "Extract" trigger, modal + image viewer stacked as direct children of the step root per AGENTS.md modal stacking rules
- Display label uses array position (`Panel 1`, `Panel 2`, …) — `orderIndex` values are sparse and never shown

### New: Panel Rendering (Step 5)
- `rendering.queries.ts` — `panelRendersOptions` query (GET `/panel/{id}/renders`)
- `usePanelRendering` hook — trigger render, edit render, set canonical, upload reference image (as `mutateAsync` for inline file upload in the render modal)
- `Carousel`, `PanelRenderingList`, `PanelRenderModal`, `NoPanelsState` components
- `PanelRenderingStep`

### Fix: Carousel is now fully controlled
- `Carousel` previously owned internal index state (`useState`), causing stale carousel position after an edit render completed — both the old and new render would appear "selected" simultaneously
- Removed internal state entirely; `Carousel` is now a pure display component driven by `index` + `onIndexChange` props owned by the parent modal
- Fixes post-edit carousel focus in both `PanelRenderModal` and `CharacterRenderModal`

### Step registry
- Steps 4 and 5 updated from `PlaceholderStep` → `PanelExtractionStep` / `PanelRenderingStep`

## API coverage

| Operation | Method | Path |
|---|---|---|
| Bulk extract | POST | `panels/generate` |
| List panels | GET | `panels` |
| Refine panel | POST | `panel/{id}/refine` |
| Render panel | POST | `panel/{id}/render` |
| List renders | GET | `panel/{id}/renders` |
| Edit render | POST | `panel/{id}/render/edit` |
| Set canonical | POST | `panel/{id}/set-canonical-render` |
| Upload ref image | POST | `panel/{id}/upload-reference-image` |
| Delete ref image | DELETE | `panel/{id}/reference-image/{imageId}` |