### PR TITLE
fix(gcs): use IAM signBlob for signed URLs on Cloud Run

### DIFF
--- a/backend/core/story_engine/service/image_service.py
+++ b/backend/core/story_engine/service/image_service.py
@@ -6,8 +6,9 @@ from functools import lru_cache
 from io import BytesIO
 from typing import BinaryIO
 
+import google.auth
+from google.auth.transport.requests import Request
 from google.cloud.storage import Client  # type: ignore[import-untyped]
-from google.oauth2 import service_account
 from loguru import logger
 from PIL import Image as PILImage
 from PIL import ImageOps
@@ -274,19 +275,23 @@ class ImageProcessor:
 
 class GCSUploadService:
     def __init__(self) -> None:
-        # Locally, load credentials explicitly from the service account key file so
-        # generate_signed_url (which requires a private key) works. On Cloud Run
-        # google_application_credentials is unset so credentials=None is passed,
-        # letting the GCS client fall back to ADC via Workload Identity (also has a
-        # private key and can sign).
-        credentials = (
-            service_account.Credentials.from_service_account_file(
-                settings.google_application_credentials
-            )
-            if settings.google_application_credentials
-            else None
+        # google.auth.default() resolves credentials from the environment:
+        #   - Locally: picks up the JSON key file via GOOGLE_APPLICATION_CREDENTIALS.
+        #              These are ServiceAccountCredentials — they hold a private key
+        #              and implement google.auth.credentials.Signing directly.
+        #   - Cloud Run: picks up the attached service account via the metadata server.
+        #              These are ComputeEngine.Credentials — they hold only a token,
+        #              NOT a private key. generate_signed_url() must therefore use
+        #              the IAM signBlob API path (access_token + service_account_email).
+        #
+        # On Cloud Run, ADC provides tokens, not a local private key. Signed URL
+        # generation therefore uses IAM-based signing (signBlob) — the SA needs
+        # roles/iam.serviceAccountTokenCreator on itself (set in infra/iam.py).
+        self.credentials, project_id = google.auth.default()
+        self.client = Client(
+            project=settings.gcp_project_id or project_id,
+            credentials=self.credentials,
         )
-        self.client = Client(project=settings.gcp_project_id, credentials=credentials)
         self.bucket = self.client.bucket(settings.gcp_storage_bucket)
 
     def upload(
@@ -311,10 +316,31 @@ class GCSUploadService:
     def generate_signed_url(self, object_key: str) -> tuple[str, datetime.datetime]:
         expiry = datetime.timedelta(minutes=SIGNED_URL_EXPIRY_MINUTES)
         blob = self.bucket.blob(object_key)
+
+        # Locally (ServiceAccountCredentials from JSON key file): credentials
+        # implement google.auth.credentials.Signing, so generate_signed_url()
+        # signs the URL locally with the private key — no extra args needed.
+        #
+        # On Cloud Run (ComputeEngine.Credentials): credentials hold only a
+        # token, not a private key. We must use the IAM signBlob API path by
+        # passing both access_token and service_account_email. The SDK branches
+        # on `if access_token and service_account_email` to call signBlob via
+        # the IAM Credentials API instead of credentials.sign_bytes().
+        # Requires roles/iam.serviceAccountTokenCreator on the SA (iam.py).
+        extra: dict = {}
+        if not hasattr(self.credentials, "sign_bytes"):
+            # Refresh to ensure token and service_account_email are populated.
+            self.credentials.refresh(Request())
+            extra = {
+                "service_account_email": self.credentials.service_account_email,
+                "access_token": self.credentials.token,
+            }
+
         url = blob.generate_signed_url(
             expiration=expiry,
             method="GET",
             version="v4",
+            **extra,
         )
         expires_at = datetime.datetime.now(datetime.timezone.utc) + expiry
         return url, expires_at

--- a/frontend/src/features/scene-engine/stories/NewStoryModal.tsx
+++ b/frontend/src/features/scene-engine/stories/NewStoryModal.tsx
@@ -13,7 +13,6 @@ import { useCreateStory } from "@/features/story/projects/hooks/useCreateStory";
 import type { StoryListEntryType } from "@/features/story/shared/story.types";
 import VoiceTextarea from "@scene-engine/components/VoiceTextarea";
 import { useState } from "react";
-import { useNavigate } from "react-router";
 import { useDeleteStory } from "./hooks/useDeleteStory";
 import { useUpdateStory } from "./hooks/useUpdateStory";
 
@@ -91,7 +90,6 @@ type StoryModalProps = {
 };
 
 export function NewStoryModal({ projectId, onDismiss, story }: StoryModalProps) {
-  const navigate = useNavigate();
   const createStory = useCreateStory();
   const updateStory = useUpdateStory();
   const deleteStory = useDeleteStory();
@@ -115,7 +113,7 @@ export function NewStoryModal({ projectId, onDismiss, story }: StoryModalProps) 
   const handleCreate = () => {
     createStory.mutate(
       { projectId, name, description, meta: currentMeta },
-      { onSuccess: () => void navigate("/stories") },
+      { onSuccess: onDismiss },
     );
   };
 

--- a/infra/components/iam.py
+++ b/infra/components/iam.py
@@ -249,6 +249,20 @@ class CloudRunServiceAccount(pulumi.ComponentResource):
             opts=pulumi.ResourceOptions(parent=self),
         )
 
+        # --- IAM signing: allow the SA to sign blobs as itself ---
+        # generate_signed_url() on Cloud Run uses the IAM Credentials API
+        # (iamcredentials.googleapis.com / signBlob) instead of a local
+        # private key. Binding Token Creator *on the SA resource itself*
+        # (not project-wide) grants only iam.serviceAccounts.signBlob for
+        # this one identity — least privilege.
+        gcp.serviceaccount.IAMMember(
+            f"{name}-token-creator-self",
+            service_account_id=self.account.name,
+            role="roles/iam.serviceAccountTokenCreator",
+            member=member,
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
         # --- Cloud SQL: allow the SA to open connections to any Cloud SQL
         # instance in the project. Project-level because Cloud SQL IAM
         # works at the project level. Grants network-level access only —


### PR DESCRIPTION
## Problem

Generating signed GCS URLs was failing on Cloud Run with:

```
you need a private key to sign credentials. the credentials you are currently using
<class 'google.auth.compute_engine.credentials.Credentials'> just contains a token.
```

The original code assumed that Cloud Run's ADC (Application Default Credentials) via Workload Identity would behave like a local JSON key file — i.e. have a private key and be able to sign locally. This assumption is wrong. On Cloud Run, ADC provides `ComputeEngine.Credentials` which hold only a short-lived OAuth token. The GCS SDK's `generate_signed_url(version='v4')` requires signing-capable credentials and raises `AttributeError` when given token-only credentials.

## Root Cause

Two things were missing:

1. **Missing IAM permission**: `cloudrun-sa` had `roles/storage.objectUser` (access to objects) but not the permission to *sign* — which goes through the IAM Credentials API (`signBlob`), not the storage API.

2. **Wrong credential assumption in code**: The `GCSUploadService` passed `credentials=None` on Cloud Run, expecting GCS to "just work" with Workload Identity. It doesn't for signing — the SDK needs to be explicitly told to use the IAM signing path.

## Changes

### `infra/components/iam.py`
Adds `roles/iam.serviceAccountTokenCreator` bound on `cloudrun-sa` **for itself** (scoped to the SA resource, not project-wide). This grants `iam.serviceAccounts.signBlob` for this identity only — least privilege. The IAM binding was already applied via `pulumi up` before this PR.

### `backend/core/story_engine/service/image_service.py`
- Replaces the conditional key-file/`None` credential init with `google.auth.default()`, which correctly resolves to `ServiceAccountCredentials` (local) or `ComputeEngine.Credentials` (Cloud Run)
- In `generate_signed_url()`, detects the credential type via presence of `sign_bytes`: if absent (Cloud Run token credentials), refreshes to populate `.token` and `.service_account_email`, then passes both to the SDK — this triggers the IAM `signBlob` API path in the SDK rather than local private-key signing
- Locally, `ServiceAccountCredentials` from the JSON key file implement `Signing` directly — behaviour is unchanged

## No new env vars or secrets
The SA email is self-discovered from the GCP metadata server at runtime. Nothing new to configure.