### PR TITLE
feat: wire auth infra and standardize on FRONTEND_URL

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -15,5 +15,4 @@ GCP_STORAGE_BUCKET=<gcp_storage_bucket>
 GCP_REGION=<gcp_region>
 GOOGLE_APPLICATION_CREDENTIALS=<google_application_credentials_location_for_local_development>
 DATABASE_URL=<database_url_for_local_development_cloud_does_not_need_this>
-# this is the frontend URL, just called cors_origins for now, will change it later 
-CORS_ORIGINS=<frontend_url>
+FRONTEND_URL=<frontend_url>

--- a/backend/core/auth_v2/api/router.py
+++ b/backend/core/auth_v2/api/router.py
@@ -34,8 +34,7 @@ router = APIRouter(prefix="/auth", tags=["auth", "google-auth"])
 
 
 def _frontend_auth_redirect(path: str) -> str:
-    frontend_base_url = settings.frontend_url or settings.cors_origins
-    return f"{frontend_base_url.rstrip('/')}{path}"
+    return f"{settings.frontend_url.rstrip('/')}{path}"
 
 
 @router.get("/login")

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -28,9 +28,8 @@ class AppSettings(BaseSettings):
     jwt_secret_key: str
     auth_session_secret: str
     google_oauth_client_id: str
-    cors_origins: str
     fernet_encryption_key: str
-    frontend_url: str = ""
+    frontend_url: str
     # Optional — only needed locally for GCS access outside Cloud Run.
     # Cloud Run services authenticate via the attached service account (no key file).
     google_application_credentials: str = ""

--- a/backend/main.py
+++ b/backend/main.py
@@ -52,14 +52,13 @@ fastapi_app.add_middleware(
 
 fastapi_app.add_middleware(CSRFMiddleware)
 
-# CORS_ORIGINS is a comma-separated list of allowed origins.
-# Defaults to localhost:5173 for local dev — no .env.local change needed.
-# In Cloud Run, injected as a plain env var from infra/components/cloudrun.py.
-_cors_origins = settings.cors_origins.split(",")
+# FRONTEND_URL is the single canonical browser origin for auth redirects and CORS.
+# It is required in both local dev and Cloud Run so backend behavior is identical
+# across environments.
 
 fastapi_app.add_middleware(
     CORSMiddleware,
-    allow_origins=_cors_origins,
+    allow_origins=[settings.frontend_url],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/infra/AGENT.md
+++ b/infra/AGENT.md
@@ -235,6 +235,12 @@ skip Secret Manager entirely. Add directly to the `plain_env_vars` dict in
 
 Then `make up` — no `populate-secrets`, no IAM changes needed.
 
+Runtime origin config follows this pattern too. For StoryEngine auth rollout,
+`FRONTEND_URL` is a plain env var managed by Pulumi, while the auth credentials
+(`GOOGLE_OAUTH_CLIENT_SECRET`, `JWT_SECRET_KEY`, `AUTH_SESSION_SECRET`,
+`FERNET_ENCRYPTION_KEY`) remain Secret Manager values populated via
+`make populate-secrets`.
+
 ---
 
 ## How the DB password is generated and wired

--- a/infra/DECISIONS.md
+++ b/infra/DECISIONS.md
@@ -259,11 +259,18 @@ stale URLs silently whenever the Cloud Run service URL changes.
 `constants.ts` is unchanged — it reads `import.meta.env.VITE_BACKEND_URL` with
 a fallback, which is always set correctly at build time via the above mechanism.
 
-### CORS_ORIGINS read from env var, not hardcoded
-`main.py` reads `CORS_ORIGINS` via `os.getenv("CORS_ORIGINS", "http://localhost:5173")`.
-Cloud Run has `CORS_ORIGINS=https://dev.dekatha.com` as a plain env var in the
-service definition. Local dev uses the default (no `.env.local` change needed).
-Adding new allowed origins = update `_PLAIN_ENV_VARS` in `cloudrun.py` + `make up`.
+### FRONTEND_URL is the canonical frontend origin in infra
+For the auth rollout, infra standardizes on a single plain env var:
+`FRONTEND_URL=https://dev.dekatha.com`. This value is used for auth redirects
+and is the intended single source of truth for browser origin policy in the
+backend as well.
+
+During the compatibility window, Cloud Run may still carry `CORS_ORIGINS` until
+the backend finishes switching to `FRONTEND_URL`. The long-term direction is one
+frontend-origin setting in infra, not separate redirect and CORS inputs.
+
+Local dev keeps using its localhost defaults from the backend app — no
+`.env.local` change is required for this production-side origin wiring.
 
 ---
 

--- a/infra/DECISIONS.md
+++ b/infra/DECISIONS.md
@@ -265,12 +265,9 @@ For the auth rollout, infra standardizes on a single plain env var:
 and is the intended single source of truth for browser origin policy in the
 backend as well.
 
-During the compatibility window, Cloud Run may still carry `CORS_ORIGINS` until
-the backend finishes switching to `FRONTEND_URL`. The long-term direction is one
-frontend-origin setting in infra, not separate redirect and CORS inputs.
-
-Local dev keeps using its localhost defaults from the backend app — no
-`.env.local` change is required for this production-side origin wiring.
+Local dev must provide the same setting in `backend/.env.local`, keeping one
+frontend-origin contract across environments instead of separate redirect and
+CORS inputs.
 
 ---
 

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -195,7 +195,7 @@ change-domain:
 	@echo "  What this does:"
 	@echo "    - Recreates the GCS bucket (must match domain — old bucket deleted)"
 	@echo "    - Replaces the SSL cert to cover the new domains"
-	@echo "    - Updates CORS_ORIGINS on Cloud Run to the new frontend domain"
+	@echo "    - Updates the frontend-origin env var on Cloud Run to the new frontend domain"
 	@echo "    - Updates URL map host rules"
 	@echo "  Expect brief HTTPS disruption while the new cert provisions."
 	@echo "  Frontend will be down until step 5 (bucket recreated but empty)."

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -108,6 +108,7 @@ init-project:
 		'  $(PULUMI_PROJECT):app: <your-app-name>        # lowercase, no spaces — drives all GCP resource names' \
 		'  $(PULUMI_PROJECT):domain: <app.yourdomain.com>' \
 		'  $(PULUMI_PROJECT):api_domain: <api.yourdomain.com>' \
+		'  $(PULUMI_PROJECT):google_oauth_client_id: <google-oauth-client-id>  # plain config, not a secret' \
 		'  $(PULUMI_PROJECT):github_repo: <owner/repo>   # SECURITY: only this repo authenticates via WIF' \
 		"  $(PULUMI_PROJECT):media_bucket_suffix: $$SUFFIX  # auto-generated — set once, NEVER change after first deploy" \
 		'  $(PULUMI_PROJECT):image_tag: latest            # updated automatically by make deploy-backend' \

--- a/infra/Pulumi.main.yaml
+++ b/infra/Pulumi.main.yaml
@@ -7,3 +7,4 @@ config:
   storyengine-infra:api_domain: api.dekatha.com
   storyengine-infra:media_bucket_suffix: x7k2
   storyengine-infra:github_repo: anudeep22003/organism
+  storyengine-infra:google_oauth_client_id: 198254519613-2lqv10fqhpm5731lhf2192n6tpdalo1h.apps.googleusercontent.com

--- a/infra/Pulumi.main.yaml.example
+++ b/infra/Pulumi.main.yaml.example
@@ -30,12 +30,15 @@ config:
 
   storyengine-infra:domain: <app.yourdomain.com> # frontend domain — GCS bucket + SSL cert + LB host rule
   storyengine-infra:api_domain: <api.yourdomain.com> # API domain — Cloud Run via same LB
+  storyengine-infra:google_oauth_client_id: <google-oauth-client-id>
+                                                 # Plain config, not a secret. Used by the backend
+                                                 # to start the Google OAuth browser flow.
 
   storyengine-infra:github_repo: <owner/repo>    # SECURITY: only this GitHub repo can authenticate
                                                  # via Workload Identity Federation. Set correctly
                                                  # before first deploy. e.g. acme/myapp
 
-  storyengine-infra:media_bucket_suffix: <run: openssl rand -hex 2>
+  storyengine-infra:media_bucket_suffix: "<run: openssl rand -hex 2>"
                                                  # Short random string for GCS bucket name uniqueness.
                                                  # Generate: openssl rand -hex 2  (gives 4 hex chars)
                                                  # IMMUTABLE after first deploy — changing it

--- a/infra/Pulumi.yaml
+++ b/infra/Pulumi.yaml
@@ -23,3 +23,6 @@ config:
   # SECURITY: only tokens from this repo can impersonate github-actions-sa.
   # Set in Pulumi.<stack>.yaml. Format: "owner/repo"  e.g. "acme/myapp"
   storyengine-infra:github_repo: ""
+  # Google OAuth client ID for the backend auth flow.
+  # Plain config, not a secret. Set in Pulumi.<stack>.yaml.
+  storyengine-infra:google_oauth_client_id: ""

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -112,6 +112,16 @@ pulumi.export("registry_url", registry.url)
 # App secret exports — StoryEngine-specific. Replace with your own when
 # starting a new project (remove these and export your own secret_ids).
 pulumi.export("secret_anthropic_api_key", secrets.anthropic_api_key.secret_id)
+pulumi.export(
+    "secret_google_oauth_client_secret",
+    secrets.google_oauth_client_secret.secret_id,
+)
+pulumi.export("secret_jwt_secret_key", secrets.jwt_secret_key.secret_id)
+pulumi.export("secret_auth_session_secret", secrets.auth_session_secret.secret_id)
+pulumi.export(
+    "secret_fernet_encryption_key",
+    secrets.fernet_encryption_key.secret_id,
+)
 pulumi.export("secret_openai_api_key", secrets.openai_api_key.secret_id)
 pulumi.export("secret_fal_api_key", secrets.fal_api_key.secret_id)
 pulumi.export("secret_database_url", secrets.database_url.secret_id)

--- a/infra/components/ci.py
+++ b/infra/components/ci.py
@@ -43,7 +43,7 @@ Design decisions:
 import pulumi
 import pulumi_gcp as gcp
 
-from components.config import APP, GITHUB_REPO, PROJECT, resource_name
+from components.config import APP, GITHUB_REPO, PROJECT
 
 # The GitHub repository that is allowed to authenticate via this pool.
 # Read from Pulumi config (github_repo key) — set per stack in Pulumi.<stack>.yaml.

--- a/infra/components/cloudrun.py
+++ b/infra/components/cloudrun.py
@@ -104,13 +104,8 @@ class CloudRunService(pulumi.ComponentResource):
                 "GCP_PROJECT_ID": PROJECT,
                 "GCP_REGION": REGION,
                 "GCP_STORAGE_BUCKET": MEDIA_BUCKET_NAME,
-                # Comma-separated list of allowed CORS origins.
-                # Read in main.py via os.getenv("CORS_ORIGINS").
-                # Not a secret — knowing this domain grants no access to anything.
-                "CORS_ORIGINS": FRONTEND_URL,
-                # Canonical frontend origin for auth redirects.
-                # Kept alongside CORS_ORIGINS during the compatibility window
-                # so backend can cut over without a big-bang deploy.
+                # Canonical frontend origin for auth redirects and browser CORS.
+                # Not a secret — it is a public origin, not a credential.
                 "FRONTEND_URL": FRONTEND_URL,
                 # Public OAuth client identifier used to start the Google auth flow.
                 "GOOGLE_OAUTH_CLIENT_ID": GOOGLE_OAUTH_CLIENT_ID,

--- a/infra/components/cloudrun.py
+++ b/infra/components/cloudrun.py
@@ -51,7 +51,8 @@ import pulumi_gcp as gcp
 
 from components.config import (
     APP,
-    DOMAIN,
+    FRONTEND_URL,
+    GOOGLE_OAUTH_CLIENT_ID,
     IMAGE_TAG,
     MEDIA_BUCKET_NAME,
     PROJECT,
@@ -106,7 +107,13 @@ class CloudRunService(pulumi.ComponentResource):
                 # Comma-separated list of allowed CORS origins.
                 # Read in main.py via os.getenv("CORS_ORIGINS").
                 # Not a secret — knowing this domain grants no access to anything.
-                "CORS_ORIGINS": f"https://{DOMAIN}",
+                "CORS_ORIGINS": FRONTEND_URL,
+                # Canonical frontend origin for auth redirects.
+                # Kept alongside CORS_ORIGINS during the compatibility window
+                # so backend can cut over without a big-bang deploy.
+                "FRONTEND_URL": FRONTEND_URL,
+                # Public OAuth client identifier used to start the Google auth flow.
+                "GOOGLE_OAUTH_CLIENT_ID": GOOGLE_OAUTH_CLIENT_ID,
                 # Disables FastAPI's /docs, /redoc, and /openapi.json in Cloud Run.
                 # Locally defaults to "development" (docs available) via config.py.
                 "ENV": "production",
@@ -156,6 +163,42 @@ class CloudRunService(pulumi.ComponentResource):
                 value_source=gcp.cloudrunv2.ServiceTemplateContainerEnvValueSourceArgs(
                     secret_key_ref=gcp.cloudrunv2.ServiceTemplateContainerEnvValueSourceSecretKeyRefArgs(
                         secret=secrets.anthropic_api_key.secret_id,
+                        version="latest",
+                    ),
+                ),
+            ),
+            gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(
+                name="GOOGLE_OAUTH_CLIENT_SECRET",
+                value_source=gcp.cloudrunv2.ServiceTemplateContainerEnvValueSourceArgs(
+                    secret_key_ref=gcp.cloudrunv2.ServiceTemplateContainerEnvValueSourceSecretKeyRefArgs(
+                        secret=secrets.google_oauth_client_secret.secret_id,
+                        version="latest",
+                    ),
+                ),
+            ),
+            gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(
+                name="JWT_SECRET_KEY",
+                value_source=gcp.cloudrunv2.ServiceTemplateContainerEnvValueSourceArgs(
+                    secret_key_ref=gcp.cloudrunv2.ServiceTemplateContainerEnvValueSourceSecretKeyRefArgs(
+                        secret=secrets.jwt_secret_key.secret_id,
+                        version="latest",
+                    ),
+                ),
+            ),
+            gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(
+                name="AUTH_SESSION_SECRET",
+                value_source=gcp.cloudrunv2.ServiceTemplateContainerEnvValueSourceArgs(
+                    secret_key_ref=gcp.cloudrunv2.ServiceTemplateContainerEnvValueSourceSecretKeyRefArgs(
+                        secret=secrets.auth_session_secret.secret_id,
+                        version="latest",
+                    ),
+                ),
+            ),
+            gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(
+                name="FERNET_ENCRYPTION_KEY",
+                value_source=gcp.cloudrunv2.ServiceTemplateContainerEnvValueSourceArgs(
+                    secret_key_ref=gcp.cloudrunv2.ServiceTemplateContainerEnvValueSourceSecretKeyRefArgs(
+                        secret=secrets.fernet_encryption_key.secret_id,
                         version="latest",
                     ),
                 ),

--- a/infra/components/config.py
+++ b/infra/components/config.py
@@ -33,6 +33,7 @@ PREFIX = f"{APP}-{STACK}"  # "storyengine-main"
 # ── App-level config ───────────────────────────────────────────────────────────
 
 IMAGE_TAG = _app.require("image_tag")  # git SHA set by make deploy-backend
+GOOGLE_OAUTH_CLIENT_ID = _app.require("google_oauth_client_id")
 
 # ── Derived values ─────────────────────────────────────────────────────────────
 
@@ -41,6 +42,7 @@ IMAGE_TAG = _app.require("image_tag")  # git SHA set by make deploy-backend
 # This decouples the domain from the stack name — "main" stack serves
 # "app.dekatha.com", a future "dev" stack can serve "dev.dekatha.com".
 DOMAIN = _app.require("domain")
+FRONTEND_URL = f"https://{DOMAIN}"
 
 # API subdomain — served via the same load balancer as the frontend.
 # Routes to the Cloud Run backend service via a Serverless NEG.

--- a/infra/components/iam.py
+++ b/infra/components/iam.py
@@ -146,6 +146,10 @@ class CloudRunServiceAccount(pulumi.ComponentResource):
         {name}-account                  gcp.serviceaccount.Account
         {name}-ar-reader                gcp.artifactregistry.RepositoryIamMember
         {name}-anthropic-accessor       gcp.secretmanager.SecretIamMember
+        {name}-google-oauth-client-secret-accessor gcp.secretmanager.SecretIamMember
+        {name}-jwt-secret-key-accessor  gcp.secretmanager.SecretIamMember
+        {name}-auth-session-secret-accessor gcp.secretmanager.SecretIamMember
+        {name}-fernet-encryption-key-accessor gcp.secretmanager.SecretIamMember
         {name}-openai-accessor          gcp.secretmanager.SecretIamMember
         {name}-fal-accessor             gcp.secretmanager.SecretIamMember
         {name}-database-accessor        gcp.secretmanager.SecretIamMember
@@ -219,6 +223,38 @@ class CloudRunServiceAccount(pulumi.ComponentResource):
         gcp.secretmanager.SecretIamMember(
             f"{name}-anthropic-accessor",
             secret_id=secrets.anthropic_api_key.secret_id,
+            role="roles/secretmanager.secretAccessor",
+            member=member,
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        gcp.secretmanager.SecretIamMember(
+            f"{name}-google-oauth-client-secret-accessor",
+            secret_id=secrets.google_oauth_client_secret.secret_id,
+            role="roles/secretmanager.secretAccessor",
+            member=member,
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        gcp.secretmanager.SecretIamMember(
+            f"{name}-jwt-secret-key-accessor",
+            secret_id=secrets.jwt_secret_key.secret_id,
+            role="roles/secretmanager.secretAccessor",
+            member=member,
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        gcp.secretmanager.SecretIamMember(
+            f"{name}-auth-session-secret-accessor",
+            secret_id=secrets.auth_session_secret.secret_id,
+            role="roles/secretmanager.secretAccessor",
+            member=member,
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        gcp.secretmanager.SecretIamMember(
+            f"{name}-fernet-encryption-key-accessor",
+            secret_id=secrets.fernet_encryption_key.secret_id,
             role="roles/secretmanager.secretAccessor",
             member=member,
             opts=pulumi.ResourceOptions(parent=self),

--- a/infra/components/secrets.py
+++ b/infra/components/secrets.py
@@ -13,6 +13,10 @@ Usage:
     secrets.db_password        # gcp.secretmanager.Secret
     # App secrets (StoryEngine-specific — replace with your own):
     secrets.anthropic_api_key  # gcp.secretmanager.Secret
+    secrets.google_oauth_client_secret  # gcp.secretmanager.Secret
+    secrets.jwt_secret_key     # gcp.secretmanager.Secret
+    secrets.auth_session_secret  # gcp.secretmanager.Secret
+    secrets.fernet_encryption_key  # gcp.secretmanager.Secret
     secrets.openai_api_key     # gcp.secretmanager.Secret
     secrets.fal_api_key        # gcp.secretmanager.Secret
 
@@ -25,6 +29,10 @@ Attributes exposed:
 
     # StoryEngine-specific — replace with your own in a new project:
     anthropic_api_key (gcp.secretmanager.Secret): Anthropic API key slot
+    google_oauth_client_secret (gcp.secretmanager.Secret): Google OAuth client secret slot
+    jwt_secret_key    (gcp.secretmanager.Secret): JWT signing key slot
+    auth_session_secret (gcp.secretmanager.Secret): Session middleware secret slot
+    fernet_encryption_key (gcp.secretmanager.Secret): Fernet key slot for encrypted OAuth tokens
     openai_api_key    (gcp.secretmanager.Secret): OpenAI API key slot
     fal_api_key       (gcp.secretmanager.Secret): Fal.ai API key slot
 
@@ -94,6 +102,10 @@ class AppSecrets(pulumi.ComponentResource):
 
     Child resources (all parented to this component):
         {name}-anthropic-api-key   gcp.secretmanager.Secret
+        {name}-google-oauth-client-secret   gcp.secretmanager.Secret
+        {name}-jwt-secret-key      gcp.secretmanager.Secret
+        {name}-auth-session-secret gcp.secretmanager.Secret
+        {name}-fernet-encryption-key gcp.secretmanager.Secret
         {name}-openai-api-key      gcp.secretmanager.Secret
         {name}-fal-api-key         gcp.secretmanager.Secret
         {name}-database-url        gcp.secretmanager.Secret
@@ -101,6 +113,10 @@ class AppSecrets(pulumi.ComponentResource):
     """
 
     anthropic_api_key: gcp.secretmanager.Secret
+    google_oauth_client_secret: gcp.secretmanager.Secret
+    jwt_secret_key: gcp.secretmanager.Secret
+    auth_session_secret: gcp.secretmanager.Secret
+    fernet_encryption_key: gcp.secretmanager.Secret
     openai_api_key: gcp.secretmanager.Secret
     fal_api_key: gcp.secretmanager.Secret
     database_url: gcp.secretmanager.Secret
@@ -152,6 +168,26 @@ class AppSecrets(pulumi.ComponentResource):
             f"{PREFIX}-anthropic-api-key",
             parent=self,
         )
+        self.google_oauth_client_secret = _make_secret(
+            f"{name}-google-oauth-client-secret",
+            f"{PREFIX}-google-oauth-client-secret",
+            parent=self,
+        )
+        self.jwt_secret_key = _make_secret(
+            f"{name}-jwt-secret-key",
+            f"{PREFIX}-jwt-secret-key",
+            parent=self,
+        )
+        self.auth_session_secret = _make_secret(
+            f"{name}-auth-session-secret",
+            f"{PREFIX}-auth-session-secret",
+            parent=self,
+        )
+        self.fernet_encryption_key = _make_secret(
+            f"{name}-fernet-encryption-key",
+            f"{PREFIX}-fernet-encryption-key",
+            parent=self,
+        )
         self.openai_api_key = _make_secret(
             f"{name}-openai-api-key",
             f"{PREFIX}-openai-api-key",
@@ -169,6 +205,10 @@ class AppSecrets(pulumi.ComponentResource):
                 "db_password": self.db_password,
                 # app secrets
                 "anthropic_api_key": self.anthropic_api_key,
+                "google_oauth_client_secret": self.google_oauth_client_secret,
+                "jwt_secret_key": self.jwt_secret_key,
+                "auth_session_secret": self.auth_session_secret,
+                "fernet_encryption_key": self.fernet_encryption_key,
                 "openai_api_key": self.openai_api_key,
                 "fal_api_key": self.fal_api_key,
             }


### PR DESCRIPTION
## Summary
- provision and wire the new auth secrets into Secret Manager, IAM, and Cloud Run
- add Pulumi-managed plain config for `GOOGLE_OAUTH_CLIENT_ID` and use `FRONTEND_URL` as the canonical frontend origin
- remove `CORS_ORIGINS` end-to-end after switching backend CORS and auth redirects to `FRONTEND_URL`

## Testing
- `uv run ruff check .` in `infra`
- backend repo checks passed during commit hook (`ruff`, format, `mypy`)
- `make preview` in `infra`
- local secret rollout validated with `make populate-secrets` and `make up`