### PR TITLE
fix(auth): make auth_v2 safe for migrations

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -24,11 +24,15 @@ load_dotenv(override=False, dotenv_path=".env.local")
 DATABASE_URL = os.environ["DATABASE_URL"]
 
 # Model imports for autogenerate support (alembic revision --autogenerate).
-from core.auth_v2 import models as auth_v2_models  # noqa: F401, E402
+#
+# Import model packages only. Do not import top-level runtime package re-exports
+# here: Alembic must register ORM metadata without triggering app settings or any
+# other runtime-only initialization.
+import core.auth_v2.models as auth_v2_models  # noqa: F401, E402
+import core.story_engine.models as story_engine_models  # noqa: F401, E402
 from core.common import ORMBase  # noqa: E402
 
-# from core.comic_builder import models as comic_builder_models  # noqa: F401
-from core.story_engine import models as story_engine_models  # noqa: F401, E402
+# import core.comic_builder.models as comic_builder_models  # noqa: F401
 
 # Alembic config object — access to values within the .ini file.
 config = context.config

--- a/backend/core/api/routers.py
+++ b/backend/core/api/routers.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 
 from core.auth.router import router as auth_router
-from core.auth_v2 import router as google_auth_router
+from core.auth_v2.api import router as google_auth_router
 from core.story_engine.api.routers import router as story_engine_router
 
 from .transcribe import router as transcribe_router

--- a/backend/core/auth_v2/__init__.py
+++ b/backend/core/auth_v2/__init__.py
@@ -1,16 +1,7 @@
-from . import models
-from .api import CSRFMiddleware, oauth, router
-from .repositories import AuthRepository
-from .security import Argon2Hasher, RefreshTokenManager
-from .services import AuthService
+"""Auth package root.
 
-__all__ = [
-    "Argon2Hasher",
-    "AuthRepository",
-    "AuthService",
-    "CSRFMiddleware",
-    "RefreshTokenManager",
-    "models",
-    "oauth",
-    "router",
-]
+Keep this module side-effect free so non-runtime consumers such as Alembic can
+import `core.auth_v2.*` modules without triggering runtime config imports.
+"""
+
+__all__: list[str] = []

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,7 @@ from loguru import logger
 from starlette.middleware.sessions import SessionMiddleware
 
 from core.api.routers import router as v1_router
-from core.auth_v2 import CSRFMiddleware
+from core.auth_v2.api import CSRFMiddleware
 from core.config import settings
 from core.logging import setup_logging
 from core.sockets import register_sio_handlers, sio

--- a/backend/tests/test_auth_v2_api.py
+++ b/backend/tests/test_auth_v2_api.py
@@ -74,7 +74,10 @@ async def _login_via_callback(
             refresh_token=refresh_token,
         )
     )
-    with patch("core.auth_v2.oauth.create_client", return_value=mock_google_client):
+    with patch(
+        "core.auth_v2.api.router.oauth.create_client",
+        return_value=mock_google_client,
+    ):
         return await api_client.get(
             "/api/auth/callback",
             headers=headers,
@@ -91,7 +94,10 @@ async def test_google_auth_login_redirects_to_google(api_client: AsyncClient) ->
         )
     )
 
-    with patch("core.auth_v2.oauth.create_client", return_value=mock_google_client):
+    with patch(
+        "core.auth_v2.api.router.oauth.create_client",
+        return_value=mock_google_client,
+    ):
         response = await api_client.get("/api/auth/login", follow_redirects=False)
 
     assert response.status_code in {302, 307}
@@ -110,7 +116,10 @@ async def test_google_auth_login_rate_limit_returns_429(
     )
     headers = {"x-forwarded-for": "198.51.100.10"}
 
-    with patch("core.auth_v2.oauth.create_client", return_value=mock_google_client):
+    with patch(
+        "core.auth_v2.api.router.oauth.create_client",
+        return_value=mock_google_client,
+    ):
         for _ in range(LOGIN_RATE_LIMIT_POLICY.max_requests):
             response = await api_client.get(
                 "/api/auth/login",
@@ -240,7 +249,10 @@ async def test_google_auth_callback_failure_redirects_to_frontend_failure(
         side_effect=RuntimeError("oauth exchange failed")
     )
 
-    with patch("core.auth_v2.oauth.create_client", return_value=mock_google_client):
+    with patch(
+        "core.auth_v2.api.router.oauth.create_client",
+        return_value=mock_google_client,
+    ):
         response = await api_client.get("/api/auth/callback", follow_redirects=False)
 
     assert response.status_code in {302, 307}
@@ -284,7 +296,10 @@ async def test_google_auth_callback_missing_userinfo_redirects_to_frontend_failu
         }
     )
 
-    with patch("core.auth_v2.oauth.create_client", return_value=mock_google_client):
+    with patch(
+        "core.auth_v2.api.router.oauth.create_client",
+        return_value=mock_google_client,
+    ):
         response = await api_client.get("/api/auth/callback", follow_redirects=False)
 
     assert response.status_code in {302, 307}
@@ -309,7 +324,10 @@ async def test_google_auth_callback_missing_required_profile_field_redirects_to_
         }
     )
 
-    with patch("core.auth_v2.oauth.create_client", return_value=mock_google_client):
+    with patch(
+        "core.auth_v2.api.router.oauth.create_client",
+        return_value=mock_google_client,
+    ):
         response = await api_client.get("/api/auth/callback", follow_redirects=False)
 
     assert response.status_code in {302, 307}

--- a/backend/tests/test_auth_v2_repository.py
+++ b/backend/tests/test_auth_v2_repository.py
@@ -3,8 +3,8 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.auth.models.user import User
-from core.auth_v2 import AuthRepository
 from core.auth_v2.models import GoogleOAuthAccount
+from core.auth_v2.repositories import AuthRepository
 
 
 async def test_create_google_oauth_account_links_to_user(

--- a/backend/tests/test_auth_v2_tokens.py
+++ b/backend/tests/test_auth_v2_tokens.py
@@ -1,6 +1,6 @@
 import uuid
 
-from core.auth_v2 import Argon2Hasher, RefreshTokenManager
+from core.auth_v2.security import Argon2Hasher, RefreshTokenManager
 
 
 def test_argon2_hasher_hashes_and_verifies_secret() -> None:


### PR DESCRIPTION
## Summary

Hotfix for the auth migration regression.

After the auth_v2 work landed, the Cloud Run migration job started failing because Alembic was indirectly importing `core/auth_v2/__init__.py`, which re-exported runtime modules that instantiate `AppSettings()`. The migration job only provides `DATABASE_URL`, so that import chain broke before Alembic could even register metadata.

This PR makes the `core.auth_v2` package root side-effect free and switches runtime/tests to direct submodule imports so Alembic can import auth model packages without pulling in app settings.

## Root Cause

```mermaid
flowchart LR
    A[alembic/env.py] --> B[core.auth_v2.* import]
    B --> C[core/auth_v2/__init__.py]
    C --> D[api/service/security re-exports]
    D --> E[core.config]
    E --> F[AppSettings()]
    F --> G[Missing env vars in migration job]
```

The migration job was supposed to need only:
- `DATABASE_URL`

But the package import chain effectively required the full runtime env.

## Fix

```mermaid
flowchart LR
    A[alembic/env.py] --> B[core.auth_v2.models import]
    B --> C[core/auth_v2/__init__.py]
    C --> D[side-effect free root]
    B --> E[ORM model registration only]
    E --> F[Alembic metadata loads]
```

Key changes:
- make `core/auth_v2/__init__.py` side-effect free
- stop importing router/middleware/repositories/security from the package root
- update runtime code to import directly from `core.auth_v2.api`
- update tests to import direct modules and patch `core.auth_v2.api.router.oauth`
- keep Alembic on a model-only import path and document the rule in `alembic/env.py`

## Why This Fix

This avoids brittle workarounds in Alembic and fixes the real problem:
- any `core.auth_v2.*` import executes the package root first
- so the package root itself must be safe for non-runtime consumers

That keeps migrations, metadata registration, and future tooling imports predictable.

## Reviewer Map

Suggested review order:
1. `backend/core/auth_v2/__init__.py`
2. `backend/alembic/env.py`
3. `backend/main.py` and `backend/core/api/routers.py`
4. `backend/tests/test_auth_v2_api.py`, `backend/tests/test_auth_v2_repository.py`, `backend/tests/test_auth_v2_tokens.py`

## Behavior Changes

No API changes.
No schema changes.
No auth-flow changes.

The only intended behavior change is:
- Alembic and other non-runtime importers can load auth_v2 model modules without requiring the full app env.

## How I Tested

- [x] Backend checks (`uv run ruff check alembic/env.py core/auth_v2 main.py core/api/routers.py tests/test_auth_v2_api.py tests/test_auth_v2_repository.py tests/test_auth_v2_tokens.py` and `uv run mypy alembic/env.py core/auth_v2 main.py core/api/routers.py tests/test_auth_v2_api.py tests/test_auth_v2_repository.py tests/test_auth_v2_tokens.py`)
- [x] Focused auth tests (`uv run pytest tests/test_auth_v2_api.py tests/test_auth_v2_repository.py tests/test_auth_v2_tokens.py`)
- [x] Minimal-env Alembic smoke check with only `DATABASE_URL` plus a stubbed Alembic context (`alembic-import-ok`)

Commit hooks also passed on commit, including repo-wide mypy.

## Checklist

- [x] Scope is small and focused
- [x] Docs/comments updated where behavior mattered
- [x] No secrets or sensitive data included
