### PR TITLE
fix(auth): use canonical api url for oauth callback

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -6,7 +6,6 @@ FAL_API_KEY=<fal_api_key>
 GOOGLE_OAUTH_CLIENT_SECRET=<google_oauth_client_secret>
 JWT_SECRET_KEY=<jwt_secret_key>
 AUTH_SESSION_SECRET=<auth_session_secret>
-GOOGLE_OAUTH_CLIENT_ID=<google_oauth_client_id>
 FERNET_ENCRYPTION_KEY=<fernet_encryption_key>
 
 # --- variables ---
@@ -16,3 +15,5 @@ GCP_REGION=<gcp_region>
 GOOGLE_APPLICATION_CREDENTIALS=<google_application_credentials_location_for_local_development>
 DATABASE_URL=<database_url_for_local_development_cloud_does_not_need_this>
 FRONTEND_URL=<frontend_url>
+API_URL=<api_url>
+GOOGLE_OAUTH_CLIENT_ID=<google_oauth_client_id>

--- a/backend/core/auth_v2/AGENTS.md
+++ b/backend/core/auth_v2/AGENTS.md
@@ -366,11 +366,12 @@ This module expects infra to provide:
 - `AUTH_SESSION_SECRET`
 - `FERNET_ENCRYPTION_KEY`
 - `FRONTEND_URL`
+- `API_URL`
 
 There is an infra handoff note in `.notes/auth-infra-handoff.md`.
 
 Important deployment assumptions:
-- Google OAuth authorized redirect URI must be `${BACKEND_URL}/api/auth/callback`
+- Google OAuth authorized redirect URI must be `${API_URL}/api/auth/callback`
 - cookie auth currently assumes same-site frontend/backend deployment characteristics because cookies use `SameSite=Lax`
 
 ## Testing Guidance

--- a/backend/core/auth_v2/api/router.py
+++ b/backend/core/auth_v2/api/router.py
@@ -37,6 +37,10 @@ def _frontend_auth_redirect(path: str) -> str:
     return f"{settings.frontend_url.rstrip('/')}{path}"
 
 
+def _google_callback_url() -> str:
+    return f"{settings.api_url.rstrip('/')}/api/auth/callback"
+
+
 @router.get("/login")
 async def login(
     request: Request,
@@ -46,7 +50,6 @@ async def login(
     ],
 ) -> RedirectResponse:
     google = oauth.create_client("google")
-    redirect_uri = str(request.url_for("callback"))
     user_agent, ip = client_context
     log_auth_event(
         "auth.login.started",
@@ -56,7 +59,7 @@ async def login(
     )
     return await google.authorize_redirect(  # type: ignore[no-any-return]
         request,
-        redirect_uri,
+        _google_callback_url(),
         access_type="offline",
         prompt="consent",
     )

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -30,6 +30,7 @@ class AppSettings(BaseSettings):
     google_oauth_client_id: str
     fernet_encryption_key: str
     frontend_url: str
+    api_url: str
     # Optional — only needed locally for GCS access outside Cloud Run.
     # Cloud Run services authenticate via the attached service account (no key file).
     google_application_credentials: str = ""

--- a/backend/tests/test_auth_v2_api.py
+++ b/backend/tests/test_auth_v2_api.py
@@ -102,6 +102,9 @@ async def test_google_auth_login_redirects_to_google(api_client: AsyncClient) ->
 
     assert response.status_code in {302, 307}
     assert response.headers["location"].startswith("https://accounts.google.com/")
+    mock_google_client.authorize_redirect.assert_awaited_once()
+    redirect_uri = mock_google_client.authorize_redirect.await_args.args[1]
+    assert redirect_uri == "https://api.dekatha.com/api/auth/callback"
 
 
 async def test_google_auth_login_rate_limit_returns_429(

--- a/infra/AGENT.md
+++ b/infra/AGENT.md
@@ -236,10 +236,10 @@ skip Secret Manager entirely. Add directly to the `plain_env_vars` dict in
 Then `make up` — no `populate-secrets`, no IAM changes needed.
 
 Runtime origin config follows this pattern too. For StoryEngine auth rollout,
-`FRONTEND_URL` is a plain env var managed by Pulumi, while the auth credentials
-(`GOOGLE_OAUTH_CLIENT_SECRET`, `JWT_SECRET_KEY`, `AUTH_SESSION_SECRET`,
-`FERNET_ENCRYPTION_KEY`) remain Secret Manager values populated via
-`make populate-secrets`.
+`FRONTEND_URL` and `API_URL` are plain env vars managed by Pulumi, while the
+auth credentials (`GOOGLE_OAUTH_CLIENT_SECRET`, `JWT_SECRET_KEY`,
+`AUTH_SESSION_SECRET`, `FERNET_ENCRYPTION_KEY`) remain Secret Manager values
+populated via `make populate-secrets`.
 
 ---
 

--- a/infra/DECISIONS.md
+++ b/infra/DECISIONS.md
@@ -261,13 +261,16 @@ a fallback, which is always set correctly at build time via the above mechanism.
 
 ### FRONTEND_URL is the canonical frontend origin in infra
 For the auth rollout, infra standardizes on a single plain env var:
-`FRONTEND_URL=https://dev.dekatha.com`. This value is used for auth redirects
-and is the intended single source of truth for browser origin policy in the
-backend as well.
+`FRONTEND_URL=https://dev.dekatha.com`. This value is used for frontend
+redirect destinations and browser CORS policy in the backend.
 
-Local dev must provide the same setting in `backend/.env.local`, keeping one
-frontend-origin contract across environments instead of separate redirect and
-CORS inputs.
+The canonical external backend origin is provided separately as:
+`API_URL=https://api.dekatha.com`. OAuth callback URLs are built from this
+value so Google always sees the public HTTPS API origin rather than an
+internally reconstructed request URL after load balancer TLS termination.
+
+Local dev must provide both settings in `backend/.env.local`, keeping the
+frontend and backend public origins explicit across environments.
 
 ---
 

--- a/infra/components/cloudrun.py
+++ b/infra/components/cloudrun.py
@@ -51,6 +51,7 @@ import pulumi_gcp as gcp
 
 from components.config import (
     APP,
+    API_URL,
     FRONTEND_URL,
     GOOGLE_OAUTH_CLIENT_ID,
     IMAGE_TAG,
@@ -107,6 +108,8 @@ class CloudRunService(pulumi.ComponentResource):
                 # Canonical frontend origin for auth redirects and browser CORS.
                 # Not a secret — it is a public origin, not a credential.
                 "FRONTEND_URL": FRONTEND_URL,
+                # Canonical external backend origin used for absolute callback URLs.
+                "API_URL": API_URL,
                 # Public OAuth client identifier used to start the Google auth flow.
                 "GOOGLE_OAUTH_CLIENT_ID": GOOGLE_OAUTH_CLIENT_ID,
                 # Disables FastAPI's /docs, /redoc, and /openapi.json in Cloud Run.

--- a/infra/components/config.py
+++ b/infra/components/config.py
@@ -48,6 +48,7 @@ FRONTEND_URL = f"https://{DOMAIN}"
 # Routes to the Cloud Run backend service via a Serverless NEG.
 # Decoupling into a separate LB is possible but costs ~$36/month extra.
 API_DOMAIN = _app.require("api_domain")
+API_URL = f"https://{API_DOMAIN}"
 
 # Media bucket name suffix — set once on first deploy, then never change.
 # GCS bucket names are globally unique and immutable; changing this suffix


### PR DESCRIPTION
## Summary
- inject canonical `API_URL` into the backend runtime from the existing infra `api_domain`
- build the Google OAuth callback URL from `API_URL` instead of `request.url_for("callback")`
- update env sample and docs to reflect the `FRONTEND_URL` / `API_URL` runtime contract

## Testing
- `uv run ruff check backend/core/config.py backend/core/auth_v2/api/router.py backend/tests/test_auth_v2_api.py infra/components/config.py infra/components/cloudrun.py`
- `API_URL=https://api.dekatha.com uv run pytest tests/test_auth_v2_api.py -q`
- `make preview` in `infra`