### PR TITLE
Fix CSRF cookie domain configuration

### DIFF
--- a/backend/core/auth/api/cookies.py
+++ b/backend/core/auth/api/cookies.py
@@ -53,6 +53,7 @@ def set_auth_cookies(
         samesite=CSRF_TOKEN_COOKIE_SAMESITE,
         max_age=REFRESH_TOKEN_TTL_SECONDS,
         path=CSRF_TOKEN_COOKIE_PATH,
+        domain=".dekatha.com",
     )
 
 

--- a/backend/core/auth/api/cookies.py
+++ b/backend/core/auth/api/cookies.py
@@ -1,5 +1,7 @@
 from fastapi import Response
 
+from core.config import settings
+
 from ..config import (
     ACCESS_TOKEN_COOKIE_HTTPONLY,
     ACCESS_TOKEN_COOKIE_NAME,
@@ -45,6 +47,15 @@ def set_auth_cookies(
         max_age=REFRESH_TOKEN_TTL_SECONDS,
         path=REFRESH_TOKEN_COOKIE_PATH,
     )
+    if settings.csrf_cookie_domain is not None:
+        # Remove the previous host-only CSRF cookie during the domain-cookie rollout.
+        response.delete_cookie(
+            key=CSRF_TOKEN_COOKIE_NAME,
+            path=CSRF_TOKEN_COOKIE_PATH,
+            httponly=CSRF_TOKEN_COOKIE_HTTPONLY,
+            secure=CSRF_TOKEN_COOKIE_SECURE,
+            samesite=CSRF_TOKEN_COOKIE_SAMESITE,
+        )
     response.set_cookie(
         key=CSRF_TOKEN_COOKIE_NAME,
         value=csrf_token,
@@ -53,7 +64,7 @@ def set_auth_cookies(
         samesite=CSRF_TOKEN_COOKIE_SAMESITE,
         max_age=REFRESH_TOKEN_TTL_SECONDS,
         path=CSRF_TOKEN_COOKIE_PATH,
-        domain=".dekatha.com",
+        domain=settings.csrf_cookie_domain,
     )
 
 
@@ -78,4 +89,14 @@ def clear_auth_cookies(response: Response) -> None:
         httponly=CSRF_TOKEN_COOKIE_HTTPONLY,
         secure=CSRF_TOKEN_COOKIE_SECURE,
         samesite=CSRF_TOKEN_COOKIE_SAMESITE,
+        domain=settings.csrf_cookie_domain,
     )
+    if settings.csrf_cookie_domain is not None:
+        # Also clear any legacy host-only CSRF cookie.
+        response.delete_cookie(
+            key=CSRF_TOKEN_COOKIE_NAME,
+            path=CSRF_TOKEN_COOKIE_PATH,
+            httponly=CSRF_TOKEN_COOKIE_HTTPONLY,
+            secure=CSRF_TOKEN_COOKIE_SECURE,
+            samesite=CSRF_TOKEN_COOKIE_SAMESITE,
+        )

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -31,6 +31,7 @@ class AppSettings(BaseSettings):
     fernet_encryption_key: str
     frontend_url: str
     api_url: str
+    csrf_cookie_domain: str | None = None
     # Optional — only needed locally for GCS access outside Cloud Run.
     # Cloud Run services authenticate via the attached service account (no key file).
     google_application_credentials: str = ""

--- a/backend/tests/test_auth_cookies.py
+++ b/backend/tests/test_auth_cookies.py
@@ -1,0 +1,81 @@
+import pytest
+from fastapi import Response
+
+from core.auth.api import cookies
+from core.auth.config import CSRF_TOKEN_COOKIE_NAME
+
+
+def _set_cookie_headers(response: Response) -> list[str]:
+    return [
+        value.decode("latin-1")
+        for key, value in response.raw_headers
+        if key.lower() == b"set-cookie"
+    ]
+
+
+def test_set_auth_cookies_uses_configured_csrf_domain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cookies.settings, "csrf_cookie_domain", "dekatha.com")
+    response = Response()
+
+    cookies.set_auth_cookies(
+        response,
+        access_token="access",
+        refresh_token="refresh",
+        csrf_token="csrf",
+    )
+
+    csrf_headers = [
+        header
+        for header in _set_cookie_headers(response)
+        if header.startswith(f"{CSRF_TOKEN_COOKIE_NAME}=")
+    ]
+    assert any("Domain=dekatha.com" in header for header in csrf_headers)
+    assert any(
+        "Max-Age=0" in header and "Domain=" not in header for header in csrf_headers
+    )
+
+
+def test_set_auth_cookies_leaves_csrf_host_only_without_domain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cookies.settings, "csrf_cookie_domain", None)
+    response = Response()
+
+    cookies.set_auth_cookies(
+        response,
+        access_token="access",
+        refresh_token="refresh",
+        csrf_token="csrf",
+    )
+
+    csrf_headers = [
+        header
+        for header in _set_cookie_headers(response)
+        if header.startswith(f"{CSRF_TOKEN_COOKIE_NAME}=")
+    ]
+    assert len(csrf_headers) == 1
+    assert "Domain=" not in csrf_headers[0]
+
+
+def test_clear_auth_cookies_deletes_domain_and_host_only_csrf(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cookies.settings, "csrf_cookie_domain", "dekatha.com")
+    response = Response()
+
+    cookies.clear_auth_cookies(response)
+
+    csrf_headers = [
+        header
+        for header in _set_cookie_headers(response)
+        if header.startswith(f"{CSRF_TOKEN_COOKIE_NAME}=")
+    ]
+    assert any(
+        "Max-Age=0" in header and "Domain=dekatha.com" in header
+        for header in csrf_headers
+    )
+    assert any(
+        "Max-Age=0" in header and "Domain=" not in header for header in csrf_headers
+    )

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+from core.config import AppSettings
+
+
+def _settings(**overrides: Any) -> AppSettings:
+    values: dict[str, Any] = {
+        "database_url": "postgresql+psycopg://user:pass@localhost:5432/db",
+        "openai_api_key": "openai",
+        "anthropic_api_key": "anthropic",
+        "fal_api_key": "fal",
+        "gcp_project_id": "project",
+        "gcp_region": "region",
+        "gcp_storage_bucket": "bucket",
+        "google_oauth_client_secret": "google-secret",
+        "jwt_secret_key": "jwt-secret",
+        "auth_session_secret": "session-secret",
+        "google_oauth_client_id": "google-client",
+        "fernet_encryption_key": "fernet-key",
+        "frontend_url": "http://localhost:5173",
+        "api_url": "http://localhost:8080",
+    }
+    values.update(overrides)
+    return AppSettings(**values)
+
+
+def test_csrf_cookie_domain_defaults_to_host_only() -> None:
+    assert _settings().csrf_cookie_domain is None
+
+
+def test_csrf_cookie_domain_can_be_configured() -> None:
+    settings = _settings(csrf_cookie_domain="dekatha.com")
+
+    assert settings.csrf_cookie_domain == "dekatha.com"

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -108,6 +108,7 @@ init-project:
 		'  $(PULUMI_PROJECT):app: <your-app-name>        # lowercase, no spaces — drives all GCP resource names' \
 		'  $(PULUMI_PROJECT):domain: <app.yourdomain.com>' \
 		'  $(PULUMI_PROJECT):api_domain: <api.yourdomain.com>' \
+		'  $(PULUMI_PROJECT):csrf_cookie_domain: <yourdomain.com>' \
 		'  $(PULUMI_PROJECT):google_oauth_client_id: <google-oauth-client-id>  # plain config, not a secret' \
 		'  $(PULUMI_PROJECT):github_repo: <owner/repo>   # SECURITY: only this repo authenticates via WIF' \
 		"  $(PULUMI_PROJECT):media_bucket_suffix: $$SUFFIX  # auto-generated — set once, NEVER change after first deploy" \
@@ -185,10 +186,12 @@ change-domain:
 	@echo "Current domains:"
 	@echo "  frontend : $$(PULUMI_CONFIG_PASSPHRASE="" pulumi config get $(PULUMI_PROJECT):domain --stack $(STACK) 2>/dev/null)"
 	@echo "  api      : $$(PULUMI_CONFIG_PASSPHRASE="" pulumi config get $(PULUMI_PROJECT):api_domain --stack $(STACK) 2>/dev/null)"
+	@echo "  csrf     : $$(PULUMI_CONFIG_PASSPHRASE="" pulumi config get $(PULUMI_PROJECT):csrf_cookie_domain --stack $(STACK) 2>/dev/null)"
 	@echo ""
-	@echo "Step 1 — Update both domains in Pulumi.$(STACK).yaml:"
+	@echo "Step 1 — Update domains in Pulumi.$(STACK).yaml:"
 	@echo "  $(PULUMI_PROJECT):domain: app.newdomain.com"
 	@echo "  $(PULUMI_PROJECT):api_domain: api.newdomain.com"
+	@echo "  $(PULUMI_PROJECT):csrf_cookie_domain: newdomain.com"
 	@echo ""
 	@echo "Step 2 — Apply infra:"
 	@echo "  make up"
@@ -196,7 +199,7 @@ change-domain:
 	@echo "  What this does:"
 	@echo "    - Recreates the GCS bucket (must match domain — old bucket deleted)"
 	@echo "    - Replaces the SSL cert to cover the new domains"
-	@echo "    - Updates the frontend-origin env var on Cloud Run to the new frontend domain"
+	@echo "    - Updates FRONTEND_URL, API_URL, and CSRF_COOKIE_DOMAIN on Cloud Run"
 	@echo "    - Updates URL map host rules"
 	@echo "  Expect brief HTTPS disruption while the new cert provisions."
 	@echo "  Frontend will be down until step 5 (bucket recreated but empty)."

--- a/infra/Pulumi.main.yaml
+++ b/infra/Pulumi.main.yaml
@@ -5,6 +5,7 @@ config:
   storyengine-infra:image_tag: 1236fcc
   storyengine-infra:domain: app.dekatha.com
   storyengine-infra:api_domain: api.dekatha.com
+  storyengine-infra:csrf_cookie_domain: dekatha.com
   storyengine-infra:media_bucket_suffix: x7k2
   storyengine-infra:github_repo: anudeep22003/organism
   storyengine-infra:google_oauth_client_id: 198254519613-2lqv10fqhpm5731lhf2192n6tpdalo1h.apps.googleusercontent.com

--- a/infra/Pulumi.main.yaml.example
+++ b/infra/Pulumi.main.yaml.example
@@ -30,6 +30,7 @@ config:
 
   storyengine-infra:domain: <app.yourdomain.com> # frontend domain — GCS bucket + SSL cert + LB host rule
   storyengine-infra:api_domain: <api.yourdomain.com> # API domain — Cloud Run via same LB
+  storyengine-infra:csrf_cookie_domain: <yourdomain.com> # Parent domain for CSRF cookie sharing across app/api subdomains
   storyengine-infra:google_oauth_client_id: <google-oauth-client-id>
                                                  # Plain config, not a secret. Used by the backend
                                                  # to start the Google OAuth browser flow.

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -8,7 +8,7 @@ import pulumi_gcp as gcp
 
 from components.ci import CiResources
 from components.cloudrun import CloudRunService
-from components.config import MEDIA_BUCKET_NAME
+from components.config import CSRF_COOKIE_DOMAIN, MEDIA_BUCKET_NAME
 from components.database import Database
 from components.frontend import Frontend
 from components.iam import CloudRunServiceAccount, LocalhostServiceAccount
@@ -135,6 +135,7 @@ pulumi.export("frontend_bucket", frontend.bucket.name)
 pulumi.export("frontend_ip", frontend.ip_address)
 pulumi.export("frontend_url", frontend.url)
 pulumi.export("api_url", frontend.api_url)
+pulumi.export("csrf_cookie_domain", CSRF_COOKIE_DOMAIN)
 pulumi.export("migration_job_name", migrations.name)
 pulumi.export("workload_identity_provider", ci.provider_name)
 pulumi.export("github_actions_sa_email", ci.sa_email)

--- a/infra/components/cloudrun.py
+++ b/infra/components/cloudrun.py
@@ -52,6 +52,7 @@ import pulumi_gcp as gcp
 from components.config import (
     APP,
     API_URL,
+    CSRF_COOKIE_DOMAIN,
     FRONTEND_URL,
     GOOGLE_OAUTH_CLIENT_ID,
     IMAGE_TAG,
@@ -110,6 +111,8 @@ class CloudRunService(pulumi.ComponentResource):
                 "FRONTEND_URL": FRONTEND_URL,
                 # Canonical external backend origin used for absolute callback URLs.
                 "API_URL": API_URL,
+                # Parent domain for the frontend-readable CSRF double-submit cookie.
+                "CSRF_COOKIE_DOMAIN": CSRF_COOKIE_DOMAIN,
                 # Public OAuth client identifier used to start the Google auth flow.
                 "GOOGLE_OAUTH_CLIENT_ID": GOOGLE_OAUTH_CLIENT_ID,
                 # Disables FastAPI's /docs, /redoc, and /openapi.json in Cloud Run.

--- a/infra/components/config.py
+++ b/infra/components/config.py
@@ -34,6 +34,7 @@ PREFIX = f"{APP}-{STACK}"  # "storyengine-main"
 
 IMAGE_TAG = _app.require("image_tag")  # git SHA set by make deploy-backend
 GOOGLE_OAUTH_CLIENT_ID = _app.require("google_oauth_client_id")
+CSRF_COOKIE_DOMAIN = _app.require("csrf_cookie_domain")
 
 # ── Derived values ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- add explicit Pulumi-managed csrf_cookie_domain config and inject CSRF_COOKIE_DOMAIN into Cloud Run
- use backend app settings for the CSRF cookie domain instead of a hardcoded value
- clear legacy host-only CSRF cookies during rollout/logout

## Tests
- uv run ruff check core/config.py core/auth/api/cookies.py tests/test_config.py tests/test_auth_cookies.py
- uv run mypy core/config.py core/auth/api/cookies.py tests/test_config.py tests/test_auth_cookies.py
- uv run pytest tests/test_config.py tests/test_auth_cookies.py
- backend commit hook: make format-check / full mypy