### PR TITLE
fix(infra): sync main backend image tag

### DIFF
--- a/infra/Pulumi.main.yaml
+++ b/infra/Pulumi.main.yaml
@@ -2,7 +2,7 @@ encryptionsalt: v1:sW+JQABkRHo=:v1:7J9KOOOv28snXCef:bsFSX1NP/El1IPwSZCzRTWoV29ZT
 config:
   gcp:project: shared-apps-infrastructure
   gcp:region: europe-west2
-  storyengine-infra:image_tag: 1236fcc
+  storyengine-infra:image_tag: cc5474b
   storyengine-infra:domain: app.dekatha.com
   storyengine-infra:api_domain: api.dekatha.com
   storyengine-infra:csrf_cookie_domain: dekatha.com


### PR DESCRIPTION
## Summary
- Sync the committed main Pulumi backend image tag to the currently deployed main commit.
- Prevent the checked-in stack config from pointing at the old March backend image after the production hotfix deploy.

## Context
Production was temporarily rolled back when Pulumi applied the stale committed image tag. This PR keeps the committed stack config aligned while we separately design a more robust deployment flow that removes release image state from committed Pulumi config.

## Testing
- Not run; configuration-only change.