### PR TITLE
fix(migrations): avoid events package settings import

### DIFF
--- a/backend/core/events/__init__.py
+++ b/backend/core/events/__init__.py
@@ -1,11 +1,1 @@
-from .models import Event, EventStatus
-from .repository import EventRepository
-from .service import EventService, emit_event
 
-__all__ = [
-    "Event",
-    "EventStatus",
-    "EventRepository",
-    "EventService",
-    "emit_event",
-]


### PR DESCRIPTION
## What changed

- Empties `core.events.__init__` so importing `core.events.models` does not eagerly import runtime services.
- Keeps Alembic model imports isolated from app settings construction.

## Why

The Cloud Run migration job only injects `DATABASE_URL`. Alembic imports `core.events.models`, but Python executes `core.events.__init__` first. The previous package init imported `core.events.service`, which imported database/settings and caused `AppSettings` validation to require full runtime config during migrations.

## Validation

- `uv run alembic heads`
- `uv run python -c "import core.events.models; print('core.events.models import ok')"`
- `uv run pytest tests/test_auth_api.py`
- `uv run ruff check core/events core/auth/services/auth.py alembic/env.py`
- Commit hook ran backend `make format-check`, including Ruff and mypy.
